### PR TITLE
Migrate scripts

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -10,12 +10,11 @@ module.exports = {
     globals: {
         // jQuery is available to use in Webflow.
         $: 'readonly',
-        // Segment globals are defined in the Webflow page's head.
+        // Segment globals are defined in the Webflow project's custom code.
         analytics: 'readonly',
-        sendEvent: 'readonly',
         // Additional globals that need to be set in the Webflow page's script.
-        PAGE_NAME: 'readonly',
-        PLAYER: 'writable'
+        PAGE_NAME: 'readonly', // A string to include as the page name for Segment events.
+        PLAYER: 'writable' // Initialize this as an empty variable.
     },
     parserOptions: {
         ecmaVersion: 2018,

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -10,8 +10,9 @@ module.exports = {
     globals: {
         // jQuery is available to use in Webflow.
         $: 'readonly',
-        // Segment globals are defined in the Webflow project's custom code.
+        // Segment analytics and Sentry globals are defined in the Webflow project's custom code.
         analytics: 'readonly',
+        Sentry: 'readonly',
         // Additional globals that need to be set in the Webflow page's script.
         PAGE_NAME: 'readonly', // A string to include as the page name for Segment events.
         PLAYER: 'writable' // Initialize this as an empty variable.

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -14,7 +14,8 @@ module.exports = {
         analytics: 'readonly',
         sendEvent: 'readonly',
         // Additional globals that need to be set in the Webflow page's script.
-        PAGE_NAME: 'readonly'
+        PAGE_NAME: 'readonly',
+        PLAYER: 'writable'
     },
     parserOptions: {
         ecmaVersion: 2018,

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,36 @@
+module.exports = {
+    env: {
+        browser: true,
+        es6: true,
+        node: true
+    },
+    extends: [
+        'eslint:recommended'
+    ],
+    globals: {
+        // jQuery is available to use in Webflow.
+        $: 'readonly',
+        // Segment globals are defined in the Webflow page's head.
+        analytics: 'readonly',
+        sendEvent: 'readonly',
+        // Additional globals that need to be set in the Webflow page's script.
+        PAGE_NAME: 'readonly'
+    },
+    parserOptions: {
+        ecmaVersion: 2018,
+        sourceType: 'module'
+    },
+    rules: {
+        'comma-dangle': ['error', 'never'],
+        'indent': ['error', 4, { 'SwitchCase': 1 }],
+        'linebreak-style': ['error', 'unix'],
+        'no-unused-vars': ['error', { 'argsIgnorePattern': '^_' }],
+        'quotes': [2, 'single'],
+        'semi': ['error', 'never'],
+        'sort-imports': 'off',
+        'no-var': 'error',
+        // Only function declarations are safely hoisted.
+        // @see https://developer.mozilla.org/en-US/docs/Glossary/Hoisting
+        'no-use-before-define': ['error', { 'functions': false, 'classes': true, 'variables': true }]
+    }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/README.md
+++ b/README.md
@@ -13,10 +13,29 @@ script.
 
 Example:
 ```html
-<script src="https://cdn.jsdelivr.net/gh/heyartifact/webflow/analytics.min.js"></script>
+<script src="https://cdn.jsdelivr.net/gh/heyartifact/webflow/src/analytics.min.js"></script>
 ```
 
 Refer to the [jsDelivr features](https://www.jsdelivr.com/features#gh) for more information.
+
+## Testing
+
+Merging script changes to `main` may affect the live page. To test these scripts without making any changes to the live
+pages, you can edit the scripts in the Webflow page to target a specific branch (such as `develop`):
+
+```html
+<script src="https://cdn.jsdelivr.net/gh/heyartifact/webflow@develop/src/analytics.min.js"></script>
+```
+
+**Remember to changes these back before publishing the Webflow page to production!**
+
+By excluding the tag, jsDelivr will fetch the latest semantic version of the script.
+
+Note that the files are cached and will not automatically fetch new versions with future commits (unless it sees that
+the version has changed). However, if a branch is cached and is stale for testing, you can also use the commit id to
+select a more up-to-date version.
+
+See more about how jsDelivr [caches files](https://github.com/jsdelivr/jsdelivr#caching).
 
 ## Globals
 

--- a/README.md
+++ b/README.md
@@ -8,34 +8,40 @@ The template for the path to load these scripts is:
 https://cdn.jsdelivr.net/gh/user/repo@version/file
 ```
 
-By excluding the tag, jsDelivr will fetch the latest semantic version of the script.
+By excluding the version tag, jsDelivr will fetch the latest semantic version of the script. However, this script will
+be cached by jsDelivr and potentially the user's browser. To avoid issues with outdated scripts being cached, make sure
+the version number is updated in Webflow's project custom code. There is a variable in the project's head,
+`ARTIFACT_SCRIPT_VERSION`, which will be used to dynamically import the correct version of the scripts.
 
 Ending the file name with `.min.js` will prompt jsDelivr to automatically create and serve a minified version of the
 script.
 
 Example:
 ```html
-<script src="https://cdn.jsdelivr.net/gh/heyartifact/webflow/src/analytics.min.js"></script>
+<script src="https://cdn.jsdelivr.net/gh/heyartifact/webflow@1.0.0/src/analytics.min.js"></script>
 ```
 
 Refer to the [jsDelivr features](https://www.jsdelivr.com/features#gh) for more information.
 
 ## Testing
 
-Merging script changes to `main` may affect the live page. To test these scripts without making any changes to the live
-pages, you can edit the scripts in the Webflow page to target a specific branch (such as `develop`):
+To stage and test changes to these scripts, you can override the version number in the page's custom code. It is
+recommended to set the version to a commit hash instead of a branch name, as branches can be cached by jsDelivr. Once
+the version is changed, publish the page to the staging URL and you can test.
 
-```html
-<script src="https://cdn.jsdelivr.net/gh/heyartifact/webflow@develop/src/analytics.min.js"></script>
-```
+Two important notes when testing:
+- Be careful not to publish the page to the live URL when you're just testing.
+- After testing, **always** remove the override to the version number! Let the central version number in the project's
+custom code be the source of truth.
 
-**Remember to changes these back before publishing the Webflow page to production!**
+## Releasing
 
-Note that the files are cached and will not automatically fetch new versions with future commits (unless it sees that
-the version has changed). However, if a branch is cached and is stale for testing, you can also use the commit id to
-select a more up-to-date version.
+To release a new version of these files:
 
-See more about how jsDelivr [caches files](https://github.com/jsdelivr/jsdelivr#caching).
+- Merge the changes into `main`
+- Publish a new release on GitHub, tagging it with the new semantic version
+- Update the `ARTIFACT_SCRIPT_VERSION` in the Webflow project's custom code head to match the new release version
+- Publish the Webflow site to allow the script changes to take effect
 
 ## Globals
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ The template for the path to load these scripts is:
 https://cdn.jsdelivr.net/gh/user/repo@version/file
 ```
 
+By excluding the tag, jsDelivr will fetch the latest semantic version of the script.
+
 Ending the file name with `.min.js` will prompt jsDelivr to automatically create and serve a minified version of the
 script.
 
@@ -28,8 +30,6 @@ pages, you can edit the scripts in the Webflow page to target a specific branch 
 ```
 
 **Remember to changes these back before publishing the Webflow page to production!**
-
-By excluding the tag, jsDelivr will fetch the latest semantic version of the script.
 
 Note that the files are cached and will not automatically fetch new versions with future commits (unless it sees that
 the version has changed). However, if a branch is cached and is stale for testing, you can also use the commit id to

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,681 @@
+{
+  "name": "webflow",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@eslint/eslintrc": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.0.tgz",
+      "integrity": "sha512-UWW0TMTmk2d7hLcWD1/e2g5HDM/HQ3csaLSqXCfqwh4uNDuNqlaKWXmEsL4Cs41Z0KnILNvwbHAah3C2yt06kw==",
+      "dev": true,
+      "requires": {
+        "ajv": "^6.12.4",
+        "debug": "^4.3.2",
+        "espree": "^9.3.2",
+        "globals": "^13.15.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.0",
+        "minimatch": "^3.1.2",
+        "strip-json-comments": "^3.1.1"
+      }
+    },
+    "@humanwhocodes/config-array": {
+      "version": "0.9.5",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.9.5.tgz",
+      "integrity": "sha512-ObyMyWxZiCu/yTisA7uzx81s40xR2fD5Cg/2Kq7G02ajkNubJf6BopgDTmDyc3U7sXpNKM8cYOw7s7Tyr+DnCw==",
+      "dev": true,
+      "requires": {
+        "@humanwhocodes/object-schema": "^1.2.1",
+        "debug": "^4.1.1",
+        "minimatch": "^3.0.4"
+      }
+    },
+    "@humanwhocodes/object-schema": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
+      "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
+      "dev": true
+    },
+    "acorn": {
+      "version": "8.8.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.0.tgz",
+      "integrity": "sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==",
+      "dev": true
+    },
+    "acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true
+    },
+    "ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dev": true,
+      "requires": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      }
+    },
+    "ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true
+    },
+    "ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "requires": {
+        "color-convert": "^2.0.1"
+      }
+    },
+    "argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true
+    },
+    "balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "requires": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true
+    },
+    "chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      }
+    },
+    "color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "requires": {
+        "color-name": "~1.1.4"
+      }
+    },
+    "color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true
+    },
+    "cross-spawn": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "dev": true,
+      "requires": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      }
+    },
+    "debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dev": true,
+      "requires": {
+        "ms": "2.1.2"
+      }
+    },
+    "deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true
+    },
+    "doctrine": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+      "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+      "dev": true,
+      "requires": {
+        "esutils": "^2.0.2"
+      }
+    },
+    "escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true
+    },
+    "eslint": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.20.0.tgz",
+      "integrity": "sha512-d4ixhz5SKCa1D6SCPrivP7yYVi7nyD6A4vs6HIAul9ujBzcEmZVM3/0NN/yu5nKhmO1wjp5xQ46iRfmDGlOviA==",
+      "dev": true,
+      "requires": {
+        "@eslint/eslintrc": "^1.3.0",
+        "@humanwhocodes/config-array": "^0.9.2",
+        "ajv": "^6.10.0",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.2",
+        "debug": "^4.3.2",
+        "doctrine": "^3.0.0",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^7.1.1",
+        "eslint-utils": "^3.0.0",
+        "eslint-visitor-keys": "^3.3.0",
+        "espree": "^9.3.2",
+        "esquery": "^1.4.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^6.0.1",
+        "functional-red-black-tree": "^1.0.1",
+        "glob-parent": "^6.0.1",
+        "globals": "^13.15.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.0.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "js-yaml": "^4.1.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "levn": "^0.4.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.2",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.1",
+        "regexpp": "^3.2.0",
+        "strip-ansi": "^6.0.1",
+        "strip-json-comments": "^3.1.0",
+        "text-table": "^0.2.0",
+        "v8-compile-cache": "^2.0.3"
+      }
+    },
+    "eslint-scope": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.1.1.tgz",
+      "integrity": "sha512-QKQM/UXpIiHcLqJ5AOyIW7XZmzjkzQXYE54n1++wb0u9V/abW3l9uQnxX8Z5Xd18xyKIMTUAyQ0k1e8pz6LUrw==",
+      "dev": true,
+      "requires": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      }
+    },
+    "eslint-utils": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
+      "integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
+      "dev": true,
+      "requires": {
+        "eslint-visitor-keys": "^2.0.0"
+      },
+      "dependencies": {
+        "eslint-visitor-keys": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
+          "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
+          "dev": true
+        }
+      }
+    },
+    "eslint-visitor-keys": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
+      "integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
+      "dev": true
+    },
+    "espree": {
+      "version": "9.3.2",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-9.3.2.tgz",
+      "integrity": "sha512-D211tC7ZwouTIuY5x9XnS0E9sWNChB7IYKX/Xp5eQj3nFXhqmiUDB9q27y76oFl8jTg3pXcQx/bpxMfs3CIZbA==",
+      "dev": true,
+      "requires": {
+        "acorn": "^8.7.1",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^3.3.0"
+      }
+    },
+    "esquery": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.4.0.tgz",
+      "integrity": "sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==",
+      "dev": true,
+      "requires": {
+        "estraverse": "^5.1.0"
+      }
+    },
+    "esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "requires": {
+        "estraverse": "^5.2.0"
+      }
+    },
+    "estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true
+    },
+    "esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true
+    },
+    "fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true
+    },
+    "fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true
+    },
+    "fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true
+    },
+    "file-entry-cache": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
+      "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
+      "dev": true,
+      "requires": {
+        "flat-cache": "^3.0.4"
+      }
+    },
+    "flat-cache": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.0.4.tgz",
+      "integrity": "sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==",
+      "dev": true,
+      "requires": {
+        "flatted": "^3.1.0",
+        "rimraf": "^3.0.2"
+      }
+    },
+    "flatted": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.6.tgz",
+      "integrity": "sha512-0sQoMh9s0BYsm+12Huy/rkKxVu4R1+r96YX5cG44rHV0pQ6iC3Q+mkoMFaGWObMFYQxCVT+ssG1ksneA2MI9KQ==",
+      "dev": true
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "dev": true
+    },
+    "functional-red-black-tree": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+      "integrity": "sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==",
+      "dev": true
+    },
+    "glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "dev": true,
+      "requires": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      }
+    },
+    "glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "requires": {
+        "is-glob": "^4.0.3"
+      }
+    },
+    "globals": {
+      "version": "13.17.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.17.0.tgz",
+      "integrity": "sha512-1C+6nQRb1GwGMKm2dH/E7enFAMxGTmGI7/dEdhy/DNelv85w9B72t3uc5frtMNXIbzrarJJ/lTCjcaZwbLJmyw==",
+      "dev": true,
+      "requires": {
+        "type-fest": "^0.20.2"
+      }
+    },
+    "has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true
+    },
+    "ignore": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
+      "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
+      "dev": true
+    },
+    "import-fresh": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
+      "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
+      "dev": true,
+      "requires": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      }
+    },
+    "imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "dev": true,
+      "requires": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
+    },
+    "is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true
+    },
+    "is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "requires": {
+        "is-extglob": "^2.1.1"
+      }
+    },
+    "isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true
+    },
+    "js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "dev": true,
+      "requires": {
+        "argparse": "^2.0.1"
+      }
+    },
+    "json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true
+    },
+    "json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true
+    },
+    "levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "requires": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      }
+    },
+    "lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true
+    },
+    "minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "requires": {
+        "brace-expansion": "^1.1.7"
+      }
+    },
+    "ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true
+    },
+    "natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "requires": {
+        "wrappy": "1"
+      }
+    },
+    "optionator": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
+      "integrity": "sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==",
+      "dev": true,
+      "requires": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.3"
+      }
+    },
+    "parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "requires": {
+        "callsites": "^3.0.0"
+      }
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "dev": true
+    },
+    "path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true
+    },
+    "prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true
+    },
+    "punycode": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "dev": true
+    },
+    "regexpp": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
+      "integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==",
+      "dev": true
+    },
+    "resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true
+    },
+    "rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "dev": true,
+      "requires": {
+        "glob": "^7.1.3"
+      }
+    },
+    "shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "requires": {
+        "shebang-regex": "^3.0.0"
+      }
+    },
+    "shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true
+    },
+    "strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "^5.0.1"
+      }
+    },
+    "strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true
+    },
+    "supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "requires": {
+        "has-flag": "^4.0.0"
+      }
+    },
+    "text-table": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+      "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
+      "dev": true
+    },
+    "type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "requires": {
+        "prelude-ls": "^1.2.1"
+      }
+    },
+    "type-fest": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+      "dev": true
+    },
+    "uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "requires": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "v8-compile-cache": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
+      "integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
+      "dev": true
+    },
+    "which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "requires": {
+        "isexe": "^2.0.0"
+      }
+    },
+    "word-wrap": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
+      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+      "dev": true
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,5 @@
 {
   "name": "webflow",
-  "version": "1.0.0",
   "description": "Public repository hosting javascript files used by webflow, and served by jsDelivr",
   "main": "",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "webflow",
+  "version": "1.0.0",
+  "description": "Public repository hosting javascript files used by webflow, and served by jsDelivr",
+  "main": "",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/heyartifact/webflow.git"
+  },
+  "author": "",
+  "license": "",
+  "bugs": {
+    "url": "https://github.com/heyartifact/webflow/issues"
+  },
+  "homepage": "https://github.com/heyartifact/webflow#readme",
+  "devDependencies": {
+    "eslint": "^8.20.0"
+  }
+}

--- a/src/analytics.js
+++ b/src/analytics.js
@@ -12,6 +12,17 @@ for (const delay of [5, 15, 30, 45]) {
 }
 
 
+function sendEvent(name, properties) {
+    // Ensure that analytics has loaded before trying to send an event.
+    if (typeof analytics !== 'undefined') {
+        analytics.track(name, {
+            page: PAGE_NAME,
+            ...properties
+        })
+    }
+}
+
+
 function getBlockProperties(block) {
     const blockVariants = {
         FAQs: 'vertical-expanding',
@@ -50,8 +61,9 @@ function getInterviewerPlayerEventProperties(target) {
 
 
 // Take the target of an event and return an object of the relevant properties to be included in the tracking event.
-function getEventProperties(eventName, dataset, target) {
+function getEventProperties(eventName, target) {
     const eventProperties = {}
+    const dataset = target.dataset
 
     // Add custom attributes that start with `data-event-` to the event properties.
     for (const attr in dataset) {
@@ -86,7 +98,6 @@ function getEventProperties(eventName, dataset, target) {
 // Assign a click event for any element with data-event-name set.
 $('[data-event-name]').click(function() {
     const target = $(this).closest('[data-event-name]')[0]
-    const dataset = target.dataset
-    const eventName = dataset['eventName']
-    sendEvent(eventName, getEventProperties(eventName, dataset, target))
+    const eventName = target.getAttribute('data-event-name')
+    sendEvent(eventName, getEventProperties(eventName, target))
 })

--- a/src/analytics.js
+++ b/src/analytics.js
@@ -50,9 +50,7 @@ function getInterviewerPlayerEventProperties(target) {
 
 
 // Take the target of an event and return an object of the relevant properties to be included in the tracking event.
-function getEventProperties(target) {
-    const dataset = target.dataset
-    const eventName = dataset['eventName']
+function getEventProperties(eventName, dataset, target) {
     const eventProperties = {}
 
     // Add custom attributes that start with `data-event-` to the event properties.
@@ -90,5 +88,5 @@ $('[data-event-name]').click(function() {
     const target = $(this).closest('[data-event-name]')[0]
     const dataset = target.dataset
     const eventName = dataset['eventName']
-    sendEvent(eventName, getEventProperties(target))
+    sendEvent(eventName, getEventProperties(eventName, dataset, target))
 })

--- a/src/analytics.js
+++ b/src/analytics.js
@@ -1,0 +1,89 @@
+if (typeof analytics !== 'undefined') {
+    analytics.page('Landing', {
+        variation: PAGE_NAME
+    })
+}
+
+for (const delay of [5, 15, 30, 45]) {
+    setTimeout(() => sendEvent('TimeOnPageThreshold Reached', {
+        page: PAGE_NAME,
+        threshold: delay.toString()
+    }), delay * 1000)
+}
+
+
+function getBlockProperties(block) {
+    const blockVariants = {
+        FAQs: 'vertical-expanding',
+        footer: 'basic',
+        inspirations: 'carousel',
+        interviewers: 'carousel',
+        'packages-and-pricing': 'basic',
+        testimonials: 'carousel',
+        ticker: 'basic',
+        topnav: 'basic',
+        'whats-included': 'basic',
+        'your-child': 'basic'
+    }
+    const additionalProperties = {}
+    if (block === 'topnav') {
+        additionalProperties['topnav-pinned'] = (window.pageYOffset || document.body.scrollTop) > 0
+    }
+    return { 'block-variant': blockVariants[block], ...additionalProperties }
+}
+
+
+function getFAQEventProperties(target) {
+    const questionText = $(target).children().first().children().first().text()
+    return { block: 'FAQs', name: questionText, type: 'question' }
+}
+
+
+function getInterviewerPlayerEventProperties(target) {
+    const interviewerCard = $(target).closest('.interviewers-block')
+    const interviewerName = $($(interviewerCard).find('.heading-6')[0]).text()
+    return {
+        content_type: 'interviewer_audio',
+        name: interviewerName
+    }
+}
+
+
+function getEventProperties(eventName, dataset, target) {
+    const eventProperties = {}
+
+    // Add custom attributes to event properties.
+    for (const attr in dataset) {
+        if (attr.startsWith('event') && attr !== 'eventName') {
+            const propName = attr.charAt(5).toLowerCase() + attr.slice(6)
+            eventProperties[propName] = dataset[attr]
+        }
+    }
+
+    if (eventName === 'FAQs Opened' && !('eventType' in dataset)) {
+        // Only send event if FAQ is being opened.
+        if ($(target).find('.answer-wrapper')[0].style.opacity !== '0') return null
+        Object.assign(eventProperties, getFAQEventProperties(target))
+    } else if (eventName === 'Player Started') {
+        if (dataset.eventBlock === 'interviewers') {
+            Object.assign(eventProperties, getInterviewerPlayerEventProperties(target))
+        } else if (dataset.eventBlock === 'your-child') {
+            eventProperties.name = 'Your child sample'
+        }
+    }
+
+    if ('block' in eventProperties) {
+        Object.assign(eventProperties, getBlockProperties(eventProperties.block))
+    }
+
+    return eventProperties
+}
+
+
+// Assign a click event for any element with data-event-name set.
+$('[data-event-name]').click(function() {
+    const target = $(this).closest('[data-event-name]')[0]
+    const dataset = target.dataset
+    const eventName = dataset['eventName']
+    sendEvent(eventName, getEventProperties(eventName, dataset, target))
+})

--- a/src/analytics.js
+++ b/src/analytics.js
@@ -49,10 +49,13 @@ function getInterviewerPlayerEventProperties(target) {
 }
 
 
-function getEventProperties(eventName, dataset, target) {
+// Take the target of an event and return an object of the relevant properties to be included in the tracking event.
+function getEventProperties(target) {
+    const dataset = target.dataset
+    const eventName = dataset['eventName']
     const eventProperties = {}
 
-    // Add custom attributes to event properties.
+    // Add custom attributes that start with `data-event-` to the event properties.
     for (const attr in dataset) {
         if (attr.startsWith('event') && attr !== 'eventName') {
             const propName = attr.charAt(5).toLowerCase() + attr.slice(6)
@@ -60,9 +63,11 @@ function getEventProperties(eventName, dataset, target) {
         }
     }
 
+    // Add additional properties for specific event names.
     if (eventName === 'FAQs Opened' && !('eventType' in dataset)) {
         // Only send event if FAQ is being opened.
         if ($(target).find('.answer-wrapper')[0].style.opacity !== '0') return null
+
         Object.assign(eventProperties, getFAQEventProperties(target))
     } else if (eventName === 'Player Started') {
         if (dataset.eventBlock === 'interviewers') {
@@ -85,5 +90,5 @@ $('[data-event-name]').click(function() {
     const target = $(this).closest('[data-event-name]')[0]
     const dataset = target.dataset
     const eventName = dataset['eventName']
-    sendEvent(eventName, getEventProperties(eventName, dataset, target))
+    sendEvent(eventName, getEventProperties(target))
 })

--- a/src/animations.js
+++ b/src/animations.js
@@ -45,11 +45,17 @@ function yourLittleOneAnimation() {
     if (CURRENT_ANIMATION_INFO.name === YOUR_LITTLE_ONE_ANIMATION) {
         const animation = ANIMATIONS[YOUR_LITTLE_ONE_ANIMATION]
         const isAudioPlaying = !PLAYER.paused && (PLAYER.querySelector('source').src === animation.expectedAudioSrc)
+
+        // animationTime represents the current progress into the animation.
+        // If the appropriate audio is playing, animationTime is the number of milliseconds from the player's
+        // currentTime.
+        // Otherwise, animationTime is the number of milliseconds since the animation was scrolled into view (and using
+        // the modulo operator to account for looping animations).
         const animationTime = (
             isAudioPlaying ?
                 PLAYER.currentTime * 1000 :
-                (new Date()).valueOf() - CURRENT_ANIMATION_INFO.timeScrolledIntoView
-        ) % animation.duration
+                ((new Date()).valueOf() - CURRENT_ANIMATION_INFO.timeScrolledIntoView) % animation.duration
+        )
 
         for (const step of animation.steps) {
             const element = document.getElementById(step.id)

--- a/src/animations.js
+++ b/src/animations.js
@@ -1,0 +1,92 @@
+const PLAYER = document.querySelector('[data-element=audio-player]')
+
+// These values should be applied to the `data-animation` attribute of the element that triggers the animation.
+const YOUR_LITTLE_ONE_ANIMATION = 'your-little-one'
+
+const ANIMATIONS = {
+    [YOUR_LITTLE_ONE_ANIMATION]: {
+        duration: 44000,
+        expectedAudioSrc: '',
+        progressBarSelector: '.your-little-one_conversation_button_progress circle',
+        startAnimation: yourLittleOneAnimation,
+        steps: [
+            {start: 500, end: 3000, id: 'ylo-text-1'},
+            {start: 3000, end: 5250, id: 'ylo-text-2'},
+            {start: 5500, end: 8000, id: 'ylo-text-3'},
+            {start: 8000, end: 11000, id: 'ylo-text-4'},
+            {start: 11000, end: 15500, id: 'ylo-text-5'},
+            {start: 15500, end: 18750, id: 'ylo-text-6'},
+            {start: 18750, end: 21750, id: 'ylo-text-7'},
+            {start: 21750, end: 24500, id: 'ylo-text-8'},
+            {start: 24500, end: 27000, id: 'ylo-text-9'},
+            {start: 27000, end: 29500, id: 'ylo-text-10'},
+            {start: 29500, end: 33000, id: 'ylo-text-11'},
+            {start: 33000, end: 35000, id: 'ylo-text-12'},
+            {start: 35000, end: 39000, id: 'ylo-text-13'}
+        ]
+    }
+}
+
+const CURRENT_ANIMATION_INFO = {
+    name: null,
+    timeScrolledIntoView: null
+}
+
+function setRadialProgressBar(animation, animationTime) {
+    const audioProgress = animationTime / animation.duration
+    const audioProgressBar = $(animation.progressBarSelector)
+    const strokeOffset = (1 - audioProgress) * 2 * Math.PI * audioProgressBar.attr('r')
+    audioProgressBar.css({ strokeDashoffset: strokeOffset })
+}
+
+function yourLittleOneAnimation() {
+    if (CURRENT_ANIMATION_INFO.name === YOUR_LITTLE_ONE_ANIMATION) {
+        const animation = ANIMATIONS[YOUR_LITTLE_ONE_ANIMATION]
+        const isAudioPlaying = !PLAYER.paused && (PLAYER.querySelector('source').src === animation.expectedAudioSrc)
+        const animationTime = (
+            isAudioPlaying ?
+                PLAYER.currentTime * 1000 :
+                (new Date()).valueOf() - CURRENT_ANIMATION_INFO.timeScrolledIntoView
+        ) % animation.duration
+
+        for (const step of animation.steps) {
+            const element = document.getElementById(step.id)
+            if (animationTime >= step.start && animationTime < step.end) {
+                element.style.opacity = '1'
+            } else {
+                element.style.opacity = '0'
+            }
+        }
+
+        setRadialProgressBar(animation, animationTime)
+
+        window.requestAnimationFrame(yourLittleOneAnimation)
+    }
+}
+
+function onPlayButtonIntersection(entries) {
+    const playButtonEntry = entries[0]
+    const animationName = playButtonEntry.target.dataset['animation']
+    if (playButtonEntry.isIntersecting && animationName in ANIMATIONS) {
+        CURRENT_ANIMATION_INFO.name = animationName
+        let timeOffset = 0
+        if (PLAYER.querySelector('source').src === ANIMATIONS[animationName].expectedAudioSrc && !PLAYER.paused) {
+            timeOffset = PLAYER.currentTime * 1000
+        }
+        CURRENT_ANIMATION_INFO.timeScrolledIntoView = (new Date()).valueOf() - timeOffset
+        ANIMATIONS[YOUR_LITTLE_ONE_ANIMATION].startAnimation()
+    } else if (CURRENT_ANIMATION_INFO.name === animationName) {
+        CURRENT_ANIMATION_INFO.name = null
+        CURRENT_ANIMATION_INFO.timeScrolledIntoView = null
+    }
+}
+
+const observer = new IntersectionObserver(onPlayButtonIntersection, {
+    root: null,
+    threshold: 0.5
+})
+const yourLittleOnePlayButton = document.querySelector('.your-little-one_conversation_button')
+observer.observe(yourLittleOnePlayButton)
+ANIMATIONS[YOUR_LITTLE_ONE_ANIMATION].expectedAudioSrc = yourLittleOnePlayButton.querySelector(
+    '[data-element=url]'
+).innerText

--- a/src/animations.js
+++ b/src/animations.js
@@ -32,12 +32,14 @@ const CURRENT_ANIMATION_INFO = {
     timeScrolledIntoView: null
 }
 
+
 function setRadialProgressBar(animation, animationTime) {
     const audioProgress = animationTime / animation.duration
     const audioProgressBar = $(animation.progressBarSelector)
     const strokeOffset = (1 - audioProgress) * 2 * Math.PI * audioProgressBar.attr('r')
     audioProgressBar.css({ strokeDashoffset: strokeOffset })
 }
+
 
 function yourLittleOneAnimation() {
     if (CURRENT_ANIMATION_INFO.name === YOUR_LITTLE_ONE_ANIMATION) {
@@ -64,6 +66,8 @@ function yourLittleOneAnimation() {
     }
 }
 
+
+// Trigger the animation to start when the play button is scrolled into view.
 function onPlayButtonIntersection(entries) {
     const playButtonEntry = entries[0]
     const animationName = playButtonEntry.target.dataset['animation']
@@ -81,12 +85,16 @@ function onPlayButtonIntersection(entries) {
     }
 }
 
-const observer = new IntersectionObserver(onPlayButtonIntersection, {
-    root: null,
-    threshold: 0.5
-})
-const yourLittleOnePlayButton = document.querySelector('.your-little-one_conversation_button')
-observer.observe(yourLittleOnePlayButton)
-ANIMATIONS[YOUR_LITTLE_ONE_ANIMATION].expectedAudioSrc = yourLittleOnePlayButton.querySelector(
-    '[data-element=url]'
-).innerText
+// Set up the animations.
+(() => {
+    const observer = new IntersectionObserver(onPlayButtonIntersection, {
+        root: null,
+        threshold: 0.5
+    })
+    const yourLittleOnePlayButton = document.querySelector('.your-little-one_conversation_button')
+    observer.observe(yourLittleOnePlayButton)
+
+    ANIMATIONS[YOUR_LITTLE_ONE_ANIMATION].expectedAudioSrc = yourLittleOnePlayButton.querySelector(
+        '[data-element=url]'
+    ).innerText
+})()

--- a/src/animations.js
+++ b/src/animations.js
@@ -1,4 +1,4 @@
-const PLAYER = document.querySelector('[data-element=audio-player]')
+PLAYER = document.querySelector('[data-element=audio-player]')
 
 // These values should be applied to the `data-animation` attribute of the element that triggers the animation.
 const YOUR_LITTLE_ONE_ANIMATION = 'your-little-one'

--- a/src/audioPlayer.js
+++ b/src/audioPlayer.js
@@ -4,18 +4,27 @@ PLAYER.querySelector('source').src = '0'
 
 const AUDIO_TOGGLES = document.querySelectorAll('[data-element=player-toggle]')
 
-AUDIO_TOGGLES.forEach((podcastTrigger) => {
-    podcastTrigger.addEventListener('click', setPlayer.bind(podcastTrigger))
+AUDIO_TOGGLES.forEach((audioToggle) => {
+    audioToggle.addEventListener('click', setPlayer.bind(audioToggle))
 })
 
 // Helper to safely call a function declared in the analytics script that should be loaded.
-function getAnalyticsEventProperties(eventName, dataset, podcastTrigger) {
+function getAnalyticsEventProperties(eventName, audioToggle) {
     if (typeof getEventProperties !== 'undefined') {
         // eslint-disable-next-line no-undef
-        return getEventProperties(eventName, dataset, podcastTrigger)
+        return getEventProperties(eventName, audioToggle)
     } else {
         console.warn('getEventProperties function not loaded!')
         return {}
+    }
+}
+
+function sendAnalyticsEvent(eventName, eventProperties) {
+    if (typeof sendEvent !== 'undefined') {
+        // eslint-disable-next-line no-undef
+        sendEvent(eventName, eventProperties)
+    } else {
+        console.warn('sendEvent function not loaded!')
     }
 }
 
@@ -38,13 +47,24 @@ function syncAudioPlayerAndAnimation() {
     }
 }
 
+
+/**
+ * Sets loads the audio file based on the button that was clicked to start the audio player.
+ *
+ * Here is a sample audio player component that should be included on the page (note that this should be inside a
+ * Webflow div with a class of `audio-wrapper` applied):
+ *
+ *  <audio class="audio-player" controls data-element="audio-player">
+ *      <source src="" type="audio/mp3">
+ *  </audio>
+ */
 async function setPlayer() {
-    const podcastTrigger = this
-    const playIconPlayer = podcastTrigger.querySelector('[data-element=play]')
-    const pauseIconPlayer = podcastTrigger.querySelector(
+    const audioToggle = this
+    const playIconPlayer = audioToggle.querySelector('[data-element=play]')
+    const pauseIconPlayer = audioToggle.querySelector(
         '[data-element=pause]'
     )
-    const audioUrl = podcastTrigger.querySelector('[data-element=url]')
+    const audioUrl = audioToggle.querySelector('[data-element=url]')
         .innerText
     const playerSrc = PLAYER.querySelector('source').src
 
@@ -74,8 +94,7 @@ async function setPlayer() {
                 PLAYER.play()
 
                 const eventName = 'Player Started'
-                const dataset = podcastTrigger.dataset
-                sendEvent(eventName, getAnalyticsEventProperties(eventName, dataset, podcastTrigger))
+                sendAnalyticsEvent(eventName, getAnalyticsEventProperties(eventName, audioToggle))
             },
             { once: true }
         )
@@ -83,11 +102,11 @@ async function setPlayer() {
 }
 
 function resetControllers() {
-    AUDIO_TOGGLES.forEach((podcastTrigger) => {
-        const playIconPlayer = podcastTrigger.querySelector(
+    AUDIO_TOGGLES.forEach((audioToggle) => {
+        const playIconPlayer = audioToggle.querySelector(
             '[data-element=play]'
         )
-        const pauseIconPlayer = podcastTrigger.querySelector(
+        const pauseIconPlayer = audioToggle.querySelector(
             '[data-element=pause]'
         )
         playIconPlayer.setAttribute('display', 'block')

--- a/src/audioPlayer.js
+++ b/src/audioPlayer.js
@@ -14,7 +14,7 @@ function getAnalyticsEventProperties(eventName, audioToggle) {
         // eslint-disable-next-line no-undef
         return getEventProperties(eventName, audioToggle)
     } else {
-        Sentry.captureMessage('`getEventProperties` function not loaded.')
+        Sentry.captureMessage('`getEventProperties` was called before it was loaded.')
         return {}
     }
 }

--- a/src/audioPlayer.js
+++ b/src/audioPlayer.js
@@ -14,7 +14,7 @@ function getAnalyticsEventProperties(eventName, audioToggle) {
         // eslint-disable-next-line no-undef
         return getEventProperties(eventName, audioToggle)
     } else {
-        console.warn('getEventProperties function not loaded!')
+        Sentry.captureMessage('`getEventProperties` function not loaded.')
         return {}
     }
 }
@@ -24,7 +24,7 @@ function sendAnalyticsEvent(eventName, eventProperties) {
         // eslint-disable-next-line no-undef
         sendEvent(eventName, eventProperties)
     } else {
-        console.warn('sendEvent function not loaded!')
+        Sentry.captureMessage('`sendEvent` was called before it was loaded.')
     }
 }
 
@@ -42,8 +42,6 @@ function syncAudioPlayerAndAnimation() {
                 ) % animation.duration) / 1000
             }
         }
-    } else {
-        console.warn('There is no animation loaded on this page.')
     }
 }
 

--- a/src/audioPlayer.js
+++ b/src/audioPlayer.js
@@ -1,4 +1,4 @@
-const PLAYER = document.querySelector('[data-element=audio-player]')
+PLAYER = document.querySelector('[data-element=audio-player]')
 PLAYER.querySelector('source').src = '0'
 
 const AUDIO_TOGGLES = document.querySelectorAll('[data-element=player-toggle]')

--- a/src/audioPlayer.js
+++ b/src/audioPlayer.js
@@ -1,3 +1,4 @@
+// Instantiate the PLAYER variable in the Webflow page's head since it is needed across multiple scripts.
 PLAYER = document.querySelector('[data-element=audio-player]')
 PLAYER.querySelector('source').src = '0'
 
@@ -7,7 +8,7 @@ AUDIO_TOGGLES.forEach((podcastTrigger) => {
     podcastTrigger.addEventListener('click', setPlayer.bind(podcastTrigger))
 })
 
-// Helper to call a function declared in another JS file that should be loaded.
+// Helper to safely call a function declared in the analytics script that should be loaded.
 function getAnalyticsEventProperties(eventName, dataset, podcastTrigger) {
     if (typeof getEventProperties !== 'undefined') {
         // eslint-disable-next-line no-undef

--- a/src/audioPlayer.js
+++ b/src/audioPlayer.js
@@ -1,0 +1,95 @@
+const PLAYER = document.querySelector('[data-element=audio-player]')
+PLAYER.querySelector('source').src = '0'
+
+const AUDIO_TOGGLES = document.querySelectorAll('[data-element=player-toggle]')
+
+AUDIO_TOGGLES.forEach((podcastTrigger) => {
+    podcastTrigger.addEventListener('click', setPlayer.bind(podcastTrigger))
+})
+
+// Helper to call a function declared in another JS file that should be loaded.
+function getAnalyticsEventProperties(eventName, dataset, podcastTrigger) {
+    if (typeof getEventProperties !== 'undefined') {
+        // eslint-disable-next-line no-undef
+        return getEventProperties(eventName, dataset, podcastTrigger)
+    } else {
+        console.warn('getEventProperties function not loaded!')
+        return {}
+    }
+}
+
+// Attempt to retrieve animation info, if it exists, and sync the audio player to the animation.
+function syncAudioPlayerAndAnimation() {
+    if (typeof CURRENT_ANIMATION_INFO !== 'undefined' && typeof ANIMATIONS !== 'undefined') {
+        // eslint-disable-next-line no-undef
+        if (CURRENT_ANIMATION_INFO.name in ANIMATIONS) {
+            // eslint-disable-next-line no-undef
+            const animation = ANIMATIONS[CURRENT_ANIMATION_INFO.name]
+            if (PLAYER.querySelector('source').src === animation.expectedAudioSrc) {
+                PLAYER.currentTime = ((
+                    // eslint-disable-next-line no-undef
+                    (new Date()).valueOf() - CURRENT_ANIMATION_INFO.timeScrolledIntoView
+                ) % animation.duration) / 1000
+            }
+        }
+    } else {
+        console.warn('There is no animation loaded on this page.')
+    }
+}
+
+async function setPlayer() {
+    const podcastTrigger = this
+    const playIconPlayer = podcastTrigger.querySelector('[data-element=play]')
+    const pauseIconPlayer = podcastTrigger.querySelector(
+        '[data-element=pause]'
+    )
+    const audioUrl = podcastTrigger.querySelector('[data-element=url]')
+        .innerText
+    const playerSrc = PLAYER.querySelector('source').src
+
+    if (playerSrc.length !== 1 && playerSrc === audioUrl) {
+        if (!PLAYER.paused) {
+            playIconPlayer.setAttribute('display', 'block')
+            pauseIconPlayer.setAttribute('display', 'none')
+
+            PLAYER.pause()
+        } else {
+            playIconPlayer.setAttribute('display', 'none')
+            pauseIconPlayer.setAttribute('display', 'block')
+            syncAudioPlayerAndAnimation()
+            PLAYER.play()
+        }
+    } else {
+        PLAYER.querySelector('source').src = audioUrl
+        PLAYER.load()
+        PLAYER.addEventListener(
+            'canplay',
+            async (_event) => {
+                playIconPlayer.setAttribute('display', 'none')
+                await resetControllers()
+                pauseIconPlayer.setAttribute('display', 'block')
+                playIconPlayer.setAttribute('display', 'none')
+                syncAudioPlayerAndAnimation()
+                PLAYER.play()
+
+                const eventName = 'Player Started'
+                const dataset = podcastTrigger.dataset
+                sendEvent(eventName, getAnalyticsEventProperties(eventName, dataset, podcastTrigger))
+            },
+            { once: true }
+        )
+    }
+}
+
+function resetControllers() {
+    AUDIO_TOGGLES.forEach((podcastTrigger) => {
+        const playIconPlayer = podcastTrigger.querySelector(
+            '[data-element=play]'
+        )
+        const pauseIconPlayer = podcastTrigger.querySelector(
+            '[data-element=pause]'
+        )
+        playIconPlayer.setAttribute('display', 'block')
+        pauseIconPlayer.setAttribute('display', 'none')
+    })
+}


### PR DESCRIPTION
These scripts are just migrated from what was already in the Webflow page scripts. I've broken them down into separate files so we can selectively load the necessary scripts:

- The `analytics` file will likely be needed on every page.
- The `audioPlayer` file will be needed on most pages.
- The `animations` file will probably only be needed on a few pages (and we may want to have separate files for each page depending on how complex the animations get).

There are some cases where a function from one file is needed in another (i.e. some of the `analytics` functions are needed in the `audioPlayer` script). I added a helper to safely attempt to execute these functions, but open to thoughts if there's a better way to handle this!

All scripts will be loaded into Webflow with the `async` attribute, and any that are dependent on other scripts will also be loaded with the `defer` attribute.

Other minor things to note in this PR:
- I added ESlint and copied all the relevant rules from `luc`.
- I started a README with some notes about implementation and testing.

I have had these scripts loaded into a sandbox page to test and make sure they were loading and interacting properly. If anyone wants to see that, let me know and I can get that staged again!