### PR TITLE
Autoplay sample question

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+*.html

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 node_modules/
-*.html
+local-testing.html

--- a/dist/animations.js
+++ b/dist/animations.js
@@ -537,19 +537,24 @@ function getSampleQuestionComponents() {
     }
 }
 function onSampleQuestionSectionIntersection(entries, audioSourceToAnimationNameMap) {
-    if (entries[0].isIntersecting) {
-        // If a sample question animation is already playing, do not start a new animation.
-        if (SAMPLE_QUESTION_ANIMATIONS.indexOf(currentAnimationInfo.name) >= 0)
-            return;
-        var firstAudioSource = $('.section-sample-questions .container-basic div[data-element="url"]').first().text();
-        var animationName = audioSourceToAnimationNameMap[firstAudioSource];
-        if (!animationName) {
-            safelyCaptureMessage('An animation could not be found for the "Pros ask the questions" block.', 'warning');
-            return;
+    if (entries.length) {
+        if (entries[0].isIntersecting) {
+            // If a sample question animation is already playing, do not start a new animation.
+            if (SAMPLE_QUESTION_ANIMATIONS.indexOf(currentAnimationInfo.name) >= 0)
+                return;
+            var firstAudioSource = $('.section-sample-questions .container-basic div[data-element="url"]').first().text();
+            var animationName = audioSourceToAnimationNameMap[firstAudioSource];
+            if (!animationName) {
+                safelyCaptureMessage('An animation could not be found for the "Pros ask the questions" block.', 'warning');
+                return;
+            }
+            currentAnimationInfo.name = animationName;
+            currentAnimationInfo.timeScrolledIntoView = (new Date()).valueOf();
+            ANIMATIONS[animationName].startAnimation();
         }
-        currentAnimationInfo.name = animationName;
-        currentAnimationInfo.timeScrolledIntoView = (new Date()).valueOf();
-        ANIMATIONS[animationName].startAnimation();
+    }
+    else {
+        safelyCaptureMessage('An intersection observer entry was not included when calling `onSampleQuestionSectionIntersection`.', 'info');
     }
 }
 // Set up the animations.

--- a/dist/animations.js
+++ b/dist/animations.js
@@ -440,7 +440,7 @@ var ANIMATIONS = (_a = {},
     },
     _a);
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-var CURRENT_ANIMATION_INFO = {
+var currentAnimationInfo = {
     name: null,
     timeScrolledIntoView: null
 };
@@ -470,9 +470,9 @@ function setRadialProgressBar(animation, animationTime) {
     audioProgressBar.css({ strokeDashoffset: strokeOffset });
 }
 function startSampleQuestionAnimation(animationName) {
-    if (CURRENT_ANIMATION_INFO.name !== animationName) {
-        CURRENT_ANIMATION_INFO.name = animationName;
-        CURRENT_ANIMATION_INFO.timeScrolledIntoView = (new Date()).valueOf();
+    if (currentAnimationInfo.name !== animationName) {
+        currentAnimationInfo.name = animationName;
+        currentAnimationInfo.timeScrolledIntoView = (new Date()).valueOf();
     }
     sampleQuestionAnimation(animationName);
 }
@@ -481,8 +481,8 @@ function sampleQuestionAnimation(animationName, karaokeState) {
     var animation = ANIMATIONS[animationName];
     var isSameAudio = (player.querySelector('source').src === animation.expectedAudioSrc);
     var isSameAudioPlaying = isSameAudio && !player.paused;
-    if (isSameAudioPlaying || CURRENT_ANIMATION_INFO.name === animationName) {
-        var animationTime = isSameAudioPlaying ? player.currentTime * 1000 : ((new Date()).valueOf() - CURRENT_ANIMATION_INFO.timeScrolledIntoView);
+    if (isSameAudioPlaying || currentAnimationInfo.name === animationName) {
+        var animationTime = isSameAudioPlaying ? player.currentTime * 1000 : ((new Date()).valueOf() - currentAnimationInfo.timeScrolledIntoView);
         // Check if the animation has been completed.
         if (!isSameAudioPlaying && animationTime > animation.duration) {
             animation.cleanupAnimation();
@@ -502,9 +502,9 @@ function sampleQuestionAnimationCleanup(animationName) {
     var animation = ANIMATIONS[animationName];
     setRadialProgressBar(animation, 0);
     attemptUpdateKaraoke(animation.karaoke, 0, null);
-    if (CURRENT_ANIMATION_INFO.name === animationName) {
-        CURRENT_ANIMATION_INFO.name = null;
-        CURRENT_ANIMATION_INFO.timeScrolledIntoView = null;
+    if (currentAnimationInfo.name === animationName) {
+        currentAnimationInfo.name = null;
+        currentAnimationInfo.timeScrolledIntoView = null;
     }
 }
 var FAILED_GET_SAMPLE_QUESTION_COMPONENTS_ATTEMPTS = 0;
@@ -539,7 +539,7 @@ function getSampleQuestionComponents() {
 function onSampleQuestionSectionIntersection(entries, audioSourceToAnimationNameMap) {
     if (entries[0].isIntersecting) {
         // If a sample question animation is already playing, do not start a new animation.
-        if (SAMPLE_QUESTION_ANIMATIONS.indexOf(CURRENT_ANIMATION_INFO.name) >= 0)
+        if (SAMPLE_QUESTION_ANIMATIONS.indexOf(currentAnimationInfo.name) >= 0)
             return;
         var sampleQuestionsContainer = $('.section-sample-questions .container-basic');
         var firstAudioSource = sampleQuestionsContainer.find('div[data-element="url"]').first().text();
@@ -548,8 +548,8 @@ function onSampleQuestionSectionIntersection(entries, audioSourceToAnimationName
             safelyCaptureMessage('An animation could not be found for the "Pros ask the questions" block.', 'warning');
             return;
         }
-        CURRENT_ANIMATION_INFO.name = animationName;
-        CURRENT_ANIMATION_INFO.timeScrolledIntoView = (new Date()).valueOf();
+        currentAnimationInfo.name = animationName;
+        currentAnimationInfo.timeScrolledIntoView = (new Date()).valueOf();
         ANIMATIONS[animationName].startAnimation();
     }
 }
@@ -570,7 +570,7 @@ function onSampleQuestionSectionIntersection(entries, audioSourceToAnimationName
         for (var sampleQuestionAudioSrc in audioSourceToAnimationNameMap) {
             var animationName = audioSourceToAnimationNameMap[sampleQuestionAudioSrc];
             if (playerSource === sampleQuestionAudioSrc) {
-                if (animationName !== CURRENT_ANIMATION_INFO.name) {
+                if (animationName !== currentAnimationInfo.name) {
                     ANIMATIONS[animationName].startAnimation();
                 }
             }

--- a/dist/animations.js
+++ b/dist/animations.js
@@ -541,8 +541,7 @@ function onSampleQuestionSectionIntersection(entries, audioSourceToAnimationName
         // If a sample question animation is already playing, do not start a new animation.
         if (SAMPLE_QUESTION_ANIMATIONS.indexOf(currentAnimationInfo.name) >= 0)
             return;
-        var sampleQuestionsContainer = $('.section-sample-questions .container-basic');
-        var firstAudioSource = sampleQuestionsContainer.find('div[data-element="url"]').first().text();
+        var firstAudioSource = $('.section-sample-questions .container-basic div[data-element="url"]').first().text();
         var animationName = audioSourceToAnimationNameMap[firstAudioSource];
         if (!animationName) {
             safelyCaptureMessage('An animation could not be found for the "Pros ask the questions" block.', 'warning');

--- a/dist/player.js
+++ b/dist/player.js
@@ -71,11 +71,11 @@ function sendAnalyticsEvent(eventName, eventProperties) {
 }
 // Attempt to retrieve animation info, if it exists, and sync the audio player to the animation.
 function syncAudioPlayerAndAnimation() {
-    if (typeof CURRENT_ANIMATION_INFO !== 'undefined' && typeof ANIMATIONS !== 'undefined') {
-        if (CURRENT_ANIMATION_INFO.name in ANIMATIONS) {
-            var animation = ANIMATIONS[CURRENT_ANIMATION_INFO.name];
+    if (typeof currentAnimationInfo !== 'undefined' && typeof ANIMATIONS !== 'undefined') {
+        if (currentAnimationInfo.name in ANIMATIONS) {
+            var animation = ANIMATIONS[currentAnimationInfo.name];
             if (player.querySelector('source').src === animation.expectedAudioSrc) {
-                player.currentTime = (((new Date()).valueOf() - CURRENT_ANIMATION_INFO.timeScrolledIntoView) % animation.duration) / 1000;
+                player.currentTime = (((new Date()).valueOf() - currentAnimationInfo.timeScrolledIntoView) % animation.duration) / 1000;
             }
         }
     }

--- a/dist/player.js
+++ b/dist/player.js
@@ -54,7 +54,6 @@ VIDEO_TOGGLES.forEach(function (videoToggle) {
 // Helper to safely call a function declared in the analytics script that should be loaded.
 function getAnalyticsEventProperties(eventName, toggleTarget) {
     if (typeof getEventProperties !== 'undefined') {
-        // eslint-disable-next-line no-undef
         return getEventProperties(eventName, toggleTarget);
     }
     else {
@@ -64,7 +63,6 @@ function getAnalyticsEventProperties(eventName, toggleTarget) {
 }
 function sendAnalyticsEvent(eventName, eventProperties) {
     if (typeof sendEvent !== 'undefined') {
-        // eslint-disable-next-line no-undef
         sendEvent(eventName, eventProperties);
     }
     else {
@@ -74,14 +72,10 @@ function sendAnalyticsEvent(eventName, eventProperties) {
 // Attempt to retrieve animation info, if it exists, and sync the audio player to the animation.
 function syncAudioPlayerAndAnimation() {
     if (typeof CURRENT_ANIMATION_INFO !== 'undefined' && typeof ANIMATIONS !== 'undefined') {
-        // eslint-disable-next-line no-undef
         if (CURRENT_ANIMATION_INFO.name in ANIMATIONS) {
-            // eslint-disable-next-line no-undef
             var animation = ANIMATIONS[CURRENT_ANIMATION_INFO.name];
             if (player.querySelector('source').src === animation.expectedAudioSrc) {
-                player.currentTime = ((
-                // eslint-disable-next-line no-undef
-                (new Date()).valueOf() - CURRENT_ANIMATION_INFO.timeScrolledIntoView) % animation.duration) / 1000;
+                player.currentTime = (((new Date()).valueOf() - CURRENT_ANIMATION_INFO.timeScrolledIntoView) % animation.duration) / 1000;
             }
         }
     }

--- a/src/animations.ts
+++ b/src/animations.ts
@@ -443,7 +443,7 @@ const ANIMATIONS: Record<AnimationName, AnimationInfo> = {
 }
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-const CURRENT_ANIMATION_INFO: CurrentAnimationInfo = {
+const currentAnimationInfo: CurrentAnimationInfo = {
     name: null,
     timeScrolledIntoView: null
 }
@@ -479,9 +479,9 @@ function setRadialProgressBar(animation: AnimationInfo, animationTime: number) {
 
 
 function startSampleQuestionAnimation(animationName: AnimationName) {
-    if (CURRENT_ANIMATION_INFO.name !== animationName) {
-        CURRENT_ANIMATION_INFO.name = animationName
-        CURRENT_ANIMATION_INFO.timeScrolledIntoView = (new Date()).valueOf()
+    if (currentAnimationInfo.name !== animationName) {
+        currentAnimationInfo.name = animationName
+        currentAnimationInfo.timeScrolledIntoView = (new Date()).valueOf()
     }
     sampleQuestionAnimation(animationName)
 }
@@ -492,9 +492,9 @@ function sampleQuestionAnimation(animationName: AnimationName, karaokeState: Kar
     const isSameAudio = (player.querySelector('source').src === animation.expectedAudioSrc)
     const isSameAudioPlaying = isSameAudio && !player.paused
 
-    if (isSameAudioPlaying || CURRENT_ANIMATION_INFO.name === animationName) {
+    if (isSameAudioPlaying || currentAnimationInfo.name === animationName) {
         const animationTime = isSameAudioPlaying ? player.currentTime * 1000 : (
-            (new Date()).valueOf() - CURRENT_ANIMATION_INFO.timeScrolledIntoView
+            (new Date()).valueOf() - currentAnimationInfo.timeScrolledIntoView
         )
 
         // Check if the animation has been completed.
@@ -518,9 +518,9 @@ function sampleQuestionAnimationCleanup(animationName: AnimationName) {
     const animation = ANIMATIONS[animationName]
     setRadialProgressBar(animation, 0)
     attemptUpdateKaraoke(animation.karaoke, 0, null)
-    if (CURRENT_ANIMATION_INFO.name === animationName) {
-        CURRENT_ANIMATION_INFO.name = null
-        CURRENT_ANIMATION_INFO.timeScrolledIntoView = null
+    if (currentAnimationInfo.name === animationName) {
+        currentAnimationInfo.name = null
+        currentAnimationInfo.timeScrolledIntoView = null
     }
 }
 
@@ -564,7 +564,7 @@ function getSampleQuestionComponents() {
 function onSampleQuestionSectionIntersection(entries: IntersectionObserverEntry[], audioSourceToAnimationNameMap: Record<string, AnimationName>) {
     if (entries[0].isIntersecting) {
         // If a sample question animation is already playing, do not start a new animation.
-        if (SAMPLE_QUESTION_ANIMATIONS.indexOf(CURRENT_ANIMATION_INFO.name) >= 0) return
+        if (SAMPLE_QUESTION_ANIMATIONS.indexOf(currentAnimationInfo.name) >= 0) return
 
         const sampleQuestionsContainer = $('.section-sample-questions .container-basic')
         const firstAudioSource = sampleQuestionsContainer.find('div[data-element="url"]').first().text()
@@ -575,8 +575,8 @@ function onSampleQuestionSectionIntersection(entries: IntersectionObserverEntry[
             return
         }
 
-        CURRENT_ANIMATION_INFO.name = animationName
-        CURRENT_ANIMATION_INFO.timeScrolledIntoView = (new Date()).valueOf()
+        currentAnimationInfo.name = animationName
+        currentAnimationInfo.timeScrolledIntoView = (new Date()).valueOf()
         ANIMATIONS[animationName].startAnimation()
     }
 }
@@ -605,7 +605,7 @@ function onSampleQuestionSectionIntersection(entries: IntersectionObserverEntry[
         for (const sampleQuestionAudioSrc in audioSourceToAnimationNameMap) {
             const animationName = audioSourceToAnimationNameMap[sampleQuestionAudioSrc]
             if (playerSource === sampleQuestionAudioSrc) {
-                if (animationName !== CURRENT_ANIMATION_INFO.name) {
+                if (animationName !== currentAnimationInfo.name) {
                     ANIMATIONS[animationName].startAnimation()
                 }
             } else {

--- a/src/animations.ts
+++ b/src/animations.ts
@@ -566,8 +566,7 @@ function onSampleQuestionSectionIntersection(entries: IntersectionObserverEntry[
         // If a sample question animation is already playing, do not start a new animation.
         if (SAMPLE_QUESTION_ANIMATIONS.indexOf(currentAnimationInfo.name) >= 0) return
 
-        const sampleQuestionsContainer = $('.section-sample-questions .container-basic')
-        const firstAudioSource = sampleQuestionsContainer.find('div[data-element="url"]').first().text()
+        const firstAudioSource = $('.section-sample-questions .container-basic div[data-element="url"]').first().text()
         const animationName = audioSourceToAnimationNameMap[firstAudioSource]
 
         if (!animationName) {

--- a/src/animations.ts
+++ b/src/animations.ts
@@ -75,7 +75,7 @@ const ANIMATIONS: Record<AnimationName, AnimationInfo> = {
             utterancesStartOffset: 0
         },
         progressBar: null,
-        startAnimation: () => sampleQuestionAnimation(SAMPLE_QUESTION_ANNA_ANIMATION)
+        startAnimation: () => startSampleQuestionAnimation(SAMPLE_QUESTION_ANNA_ANIMATION)
     },
     [SAMPLE_QUESTION_GEORGE_ANIMATION]: {
         cleanupAnimation: () => sampleQuestionAnimationCleanup(SAMPLE_QUESTION_GEORGE_ANIMATION),
@@ -164,7 +164,7 @@ const ANIMATIONS: Record<AnimationName, AnimationInfo> = {
             utterancesStartOffset: 0
         },
         progressBar: null,
-        startAnimation: () => sampleQuestionAnimation(SAMPLE_QUESTION_GEORGE_ANIMATION)
+        startAnimation: () => startSampleQuestionAnimation(SAMPLE_QUESTION_GEORGE_ANIMATION)
     },
     [SAMPLE_QUESTION_JULIE_ANIMATION]: {
         cleanupAnimation: () => sampleQuestionAnimationCleanup(SAMPLE_QUESTION_JULIE_ANIMATION),
@@ -261,7 +261,7 @@ const ANIMATIONS: Record<AnimationName, AnimationInfo> = {
             utterancesStartOffset: 0
         },
         progressBar: null,
-        startAnimation: () => sampleQuestionAnimation(SAMPLE_QUESTION_JULIE_ANIMATION)
+        startAnimation: () => startSampleQuestionAnimation(SAMPLE_QUESTION_JULIE_ANIMATION)
     },
     [SAMPLE_QUESTION_MIKE_ANIMATION]: {
         cleanupAnimation: () => sampleQuestionAnimationCleanup(SAMPLE_QUESTION_MIKE_ANIMATION),
@@ -330,7 +330,7 @@ const ANIMATIONS: Record<AnimationName, AnimationInfo> = {
             utterancesStartOffset: 0
         },
         progressBar: null,
-        startAnimation: () => sampleQuestionAnimation(SAMPLE_QUESTION_MIKE_ANIMATION)
+        startAnimation: () => startSampleQuestionAnimation(SAMPLE_QUESTION_MIKE_ANIMATION)
     },
     [SAMPLE_QUESTION_PRIA_ANIMATION]: {
         cleanupAnimation: () => sampleQuestionAnimationCleanup(SAMPLE_QUESTION_PRIA_ANIMATION),
@@ -390,7 +390,7 @@ const ANIMATIONS: Record<AnimationName, AnimationInfo> = {
             utterancesStartOffset: 0
         },
         progressBar: null,
-        startAnimation: () => sampleQuestionAnimation(SAMPLE_QUESTION_PRIA_ANIMATION)
+        startAnimation: () => startSampleQuestionAnimation(SAMPLE_QUESTION_PRIA_ANIMATION)
     },
     [SAMPLE_QUESTION_RUTHIE_ANIMATION]: {
         cleanupAnimation: () => sampleQuestionAnimationCleanup(SAMPLE_QUESTION_RUTHIE_ANIMATION),
@@ -438,7 +438,7 @@ const ANIMATIONS: Record<AnimationName, AnimationInfo> = {
             utterancesStartOffset: 0
         },
         progressBar: null,
-        startAnimation: () => sampleQuestionAnimation(SAMPLE_QUESTION_RUTHIE_ANIMATION)
+        startAnimation: () => startSampleQuestionAnimation(SAMPLE_QUESTION_RUTHIE_ANIMATION)
     }
 }
 
@@ -478,13 +478,31 @@ function setRadialProgressBar(animation: AnimationInfo, animationTime: number) {
 }
 
 
+function startSampleQuestionAnimation(animationName: AnimationName) {
+    if (CURRENT_ANIMATION_INFO.name !== animationName) {
+        CURRENT_ANIMATION_INFO.name = animationName
+        CURRENT_ANIMATION_INFO.timeScrolledIntoView = (new Date()).valueOf()
+    }
+    sampleQuestionAnimation(animationName)
+}
+
+
 function sampleQuestionAnimation(animationName: AnimationName, karaokeState: KaraokeState = null) {
     const animation = ANIMATIONS[animationName]
     const isSameAudio = (player.querySelector('source').src === animation.expectedAudioSrc)
     const isSameAudioPlaying = isSameAudio && !player.paused
 
-    if (isSameAudioPlaying) {
-        const animationTime = player.currentTime * 1000
+    if (isSameAudioPlaying || CURRENT_ANIMATION_INFO.name === animationName) {
+        const animationTime = isSameAudioPlaying ? player.currentTime * 1000 : (
+            (new Date()).valueOf() - CURRENT_ANIMATION_INFO.timeScrolledIntoView
+        )
+
+        // Check if the animation has been completed.
+        if (!isSameAudioPlaying && animationTime > animation.duration) {
+            animation.cleanupAnimation()
+            return
+        }
+
         setRadialProgressBar(animation, animationTime)
         karaokeState = attemptUpdateKaraoke(animation.karaoke, animationTime, karaokeState)
         window.requestAnimationFrame(() => sampleQuestionAnimation(animationName, karaokeState))
@@ -500,6 +518,10 @@ function sampleQuestionAnimationCleanup(animationName: AnimationName) {
     const animation = ANIMATIONS[animationName]
     setRadialProgressBar(animation, 0)
     attemptUpdateKaraoke(animation.karaoke, 0, null)
+    if (CURRENT_ANIMATION_INFO.name === animationName) {
+        CURRENT_ANIMATION_INFO.name = null
+        CURRENT_ANIMATION_INFO.timeScrolledIntoView = null
+    }
 }
 
 
@@ -539,25 +561,58 @@ function getSampleQuestionComponents() {
 }
 
 
+function onSampleQuestionSectionIntersection(entries: IntersectionObserverEntry[], audioSourceToAnimationNameMap: Record<string, AnimationName>) {
+    if (entries[0].isIntersecting) {
+        // If a sample question animation is already playing, do not start a new animation.
+        if (SAMPLE_QUESTION_ANIMATIONS.indexOf(CURRENT_ANIMATION_INFO.name) >= 0) return
+
+        const sampleQuestionsContainer = $('.section-sample-questions .container-basic')
+        const firstAudioSource = sampleQuestionsContainer.find('div[data-element="url"]').first().text()
+        const animationName = audioSourceToAnimationNameMap[firstAudioSource]
+
+        if (!animationName) {
+            safelyCaptureMessage('An animation could not be found for the "Pros ask the questions" block.', 'warning')
+            return
+        }
+
+        CURRENT_ANIMATION_INFO.name = animationName
+        CURRENT_ANIMATION_INFO.timeScrolledIntoView = (new Date()).valueOf()
+        ANIMATIONS[animationName].startAnimation()
+    }
+}
+
+
 // Set up the animations.
 (() => {
-    getSampleQuestionComponents()
-
     const audioSourceToAnimationNameMap: Record<string, AnimationName> = {}
     SAMPLE_QUESTION_ANIMATIONS.forEach((animationName) => {
         audioSourceToAnimationNameMap[ANIMATIONS[animationName].expectedAudioSrc] = animationName
     })
 
+    const sampleQuestionSectionObserver = new IntersectionObserver(
+        entries => onSampleQuestionSectionIntersection(entries, audioSourceToAnimationNameMap),
+        { threshold: 0.75 }
+    )
+    const sampleQuestionSection = $('.section-sample-questions')
+    if (sampleQuestionSection.length) {
+        sampleQuestionSectionObserver.observe(sampleQuestionSection[0])
+    }
+
+    getSampleQuestionComponents()
+
     $(player).on('play', () => {
         const playerSource = $(player).find('source').attr('src')
         for (const sampleQuestionAudioSrc in audioSourceToAnimationNameMap) {
+            const animationName = audioSourceToAnimationNameMap[sampleQuestionAudioSrc]
             if (playerSource === sampleQuestionAudioSrc) {
-                sampleQuestionAnimation(audioSourceToAnimationNameMap[sampleQuestionAudioSrc])
+                if (animationName !== CURRENT_ANIMATION_INFO.name) {
+                    ANIMATIONS[animationName].startAnimation()
+                }
             } else {
                 // A karaoke animation could be paused halfway through even though the audio will restart from the
                 // beginning when the play button is clicked again. Reset the animation so the words are all
                 // semi-transparent and the progress bar goes back to 0%.
-                sampleQuestionAnimationCleanup(audioSourceToAnimationNameMap[sampleQuestionAudioSrc])
+                sampleQuestionAnimationCleanup(animationName)
             }
         }
     })

--- a/src/animations.ts
+++ b/src/animations.ts
@@ -562,21 +562,28 @@ function getSampleQuestionComponents() {
 
 
 function onSampleQuestionSectionIntersection(entries: IntersectionObserverEntry[], audioSourceToAnimationNameMap: Record<string, AnimationName>) {
-    if (entries[0].isIntersecting) {
-        // If a sample question animation is already playing, do not start a new animation.
-        if (SAMPLE_QUESTION_ANIMATIONS.indexOf(currentAnimationInfo.name) >= 0) return
+    if (entries.length) {
+        if (entries[0].isIntersecting) {
+            // If a sample question animation is already playing, do not start a new animation.
+            if (SAMPLE_QUESTION_ANIMATIONS.indexOf(currentAnimationInfo.name) >= 0) return
 
-        const firstAudioSource = $('.section-sample-questions .container-basic div[data-element="url"]').first().text()
-        const animationName = audioSourceToAnimationNameMap[firstAudioSource]
+            const firstAudioSource = $('.section-sample-questions .container-basic div[data-element="url"]').first().text()
+            const animationName = audioSourceToAnimationNameMap[firstAudioSource]
 
-        if (!animationName) {
-            safelyCaptureMessage('An animation could not be found for the "Pros ask the questions" block.', 'warning')
-            return
+            if (!animationName) {
+                safelyCaptureMessage('An animation could not be found for the "Pros ask the questions" block.', 'warning')
+                return
+            }
+
+            currentAnimationInfo.name = animationName
+            currentAnimationInfo.timeScrolledIntoView = (new Date()).valueOf()
+            ANIMATIONS[animationName].startAnimation()
         }
-
-        currentAnimationInfo.name = animationName
-        currentAnimationInfo.timeScrolledIntoView = (new Date()).valueOf()
-        ANIMATIONS[animationName].startAnimation()
+    } else {
+        safelyCaptureMessage(
+            'An intersection observer entry was not included when calling `onSampleQuestionSectionIntersection`.',
+            'info'
+        )
     }
 }
 

--- a/src/player.ts
+++ b/src/player.ts
@@ -26,7 +26,6 @@ VIDEO_TOGGLES.forEach(videoToggle => {
 // Helper to safely call a function declared in the analytics script that should be loaded.
 function getAnalyticsEventProperties(eventName: string, toggleTarget: HTMLElement) {
     if (typeof getEventProperties !== 'undefined') {
-        // eslint-disable-next-line no-undef
         return getEventProperties(eventName, toggleTarget)
     } else {
         safelyCaptureMessage('`getEventProperties` was called before it was loaded.')
@@ -37,7 +36,6 @@ function getAnalyticsEventProperties(eventName: string, toggleTarget: HTMLElemen
 
 function sendAnalyticsEvent(eventName: string, eventProperties: EventProperties) {
     if (typeof sendEvent !== 'undefined') {
-        // eslint-disable-next-line no-undef
         sendEvent(eventName, eventProperties)
     } else {
         safelyCaptureMessage('`sendEvent` was called before it was loaded.')
@@ -48,13 +46,10 @@ function sendAnalyticsEvent(eventName: string, eventProperties: EventProperties)
 // Attempt to retrieve animation info, if it exists, and sync the audio player to the animation.
 function syncAudioPlayerAndAnimation() {
     if (typeof CURRENT_ANIMATION_INFO !== 'undefined' && typeof ANIMATIONS !== 'undefined') {
-        // eslint-disable-next-line no-undef
         if (CURRENT_ANIMATION_INFO.name in ANIMATIONS) {
-            // eslint-disable-next-line no-undef
             const animation = ANIMATIONS[CURRENT_ANIMATION_INFO.name]
             if (player.querySelector('source').src === animation.expectedAudioSrc) {
                 player.currentTime = ((
-                    // eslint-disable-next-line no-undef
                     (new Date()).valueOf() - CURRENT_ANIMATION_INFO.timeScrolledIntoView
                 ) % animation.duration) / 1000
             }

--- a/src/player.ts
+++ b/src/player.ts
@@ -45,12 +45,12 @@ function sendAnalyticsEvent(eventName: string, eventProperties: EventProperties)
 
 // Attempt to retrieve animation info, if it exists, and sync the audio player to the animation.
 function syncAudioPlayerAndAnimation() {
-    if (typeof CURRENT_ANIMATION_INFO !== 'undefined' && typeof ANIMATIONS !== 'undefined') {
-        if (CURRENT_ANIMATION_INFO.name in ANIMATIONS) {
-            const animation = ANIMATIONS[CURRENT_ANIMATION_INFO.name]
+    if (typeof currentAnimationInfo !== 'undefined' && typeof ANIMATIONS !== 'undefined') {
+        if (currentAnimationInfo.name in ANIMATIONS) {
+            const animation = ANIMATIONS[currentAnimationInfo.name]
             if (player.querySelector('source').src === animation.expectedAudioSrc) {
                 player.currentTime = ((
-                    (new Date()).valueOf() - CURRENT_ANIMATION_INFO.timeScrolledIntoView
+                    (new Date()).valueOf() - currentAnimationInfo.timeScrolledIntoView
                 ) % animation.duration) / 1000
             }
         }


### PR DESCRIPTION
- The first question in the sample questions block will start autoplaying when you scroll the block into view
- I set the threshold to 75%, so the animation should be mostly in view before it starts
- A new animation won't start if one of the sample questions already has an ongoing animation (possible if you start playing a card and scroll away from and back to the block)

Demo (tablet/mobile only): https://heyartifact.webflow.io/kids