### PR TITLE
Analytics improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,15 @@ Required custom attributes:
 - `data-event-block`
 - `data-event-label`
 
+### The `FAQs Opened` Event
+
+To have an element trigger this, assign the `data-event-name` attribute with a value of `FAQs Opened`. No additional
+attributes are required.
+
+This script for this relies on the opacity of the FAQ answer being changed to know when it is actually opened (we do not
+trigger an event when the FAQ is closed). If the styling/animation changes for these elements, it could impact the
+ability to track this event.
+
 ### The `Viewed Landing Page Block` Event
 
 To have an element trigger this, assign the `data-event-name` attribute with a value of `Viewed Landing Page Block`.

--- a/README.md
+++ b/README.md
@@ -33,6 +33,29 @@ The recommended import order is as follows:
 - `animations`
 - `player`
 
+## Sending Segment Events
+
+To send Segment events, the elements in Webflow will need to have custom attributes assigned to them. Instructions on
+sending each event are included below.
+
+In addition to the required custom attributes, any custom attribute beginning with `data-event-` will automatically be
+included in the payload.
+
+### The `Button Clicked` Event
+
+To have an element trigger this, assign the `data-event-name` attribute with a value of `Button Clicked`.
+
+Required custom attributes:
+- `data-event-block`
+- `data-event-label`
+
+### The `Viewed Landing Page Block` Event
+
+To have an element trigger this, assign the `data-event-name` attribute with a value of `Viewed Landing Page Block`.
+
+Required custom attributes:
+- `data-event-block`
+
 ## Testing
 
 To stage and test changes to these scripts, you can override the version number in the page's custom code. It is

--- a/dist/analytics.js
+++ b/dist/analytics.js
@@ -83,7 +83,7 @@ function getBlockProperties(block) {
         'your-child': 'basic'
     };
     if (!(block in blockVariants)) {
-        safelyCaptureMessage("The ".concat(block, " block is not defined getBlockProperties."), 'warning');
+        safelyCaptureMessage("An invalid block name, ".concat(block, ", was passed to getBlockProperties."), 'warning');
         return {};
     }
     var blockProperties = { 'block-variant': blockVariants[block] };

--- a/dist/analytics.js
+++ b/dist/analytics.js
@@ -75,6 +75,10 @@ function getBlockProperties(block) {
         'whats-included': 'basic',
         'your-child': 'basic'
     };
+    if (!(block in blockVariants)) {
+        safelyCaptureMessage("The ".concat(block, " block is not defined getBlockProperties."), 'warning');
+        return {};
+    }
     var blockProperties = { 'block-variant': blockVariants[block] };
     if (block === 'topnav') {
         // TODO: This will not be adequate for the interactive hero section where the topnav does not get pinned until
@@ -143,6 +147,10 @@ $('[data-event-name]').on('click', function () {
     var target = $(this).closest('[data-event-name]')[0];
     var eventName = target.getAttribute('data-event-name');
     var eventProperties = getEventProperties(eventName, target);
+    // All click events should have a `block` property defined.
+    if (!('block' in eventProperties)) {
+        safelyCaptureMessage("The block property has not been set for a click event with the name, ".concat(eventName, "."), 'warning');
+    }
     // `getEventProperties` will return `null` if the event should not be sent.
     if (eventProperties)
         sendEvent(eventName, eventProperties);

--- a/dist/analytics.js
+++ b/dist/analytics.js
@@ -9,6 +9,11 @@ var __assign = (this && this.__assign) || function () {
     };
     return __assign.apply(this, arguments);
 };
+var buttonClickedEventName = 'Button Clicked';
+var viewedLandingPageBlockEventName = 'Viewed Landing Page Block';
+// We don't want to send the `Viewed Landing Page Block` event multiple times per block on the same visit, so use this
+// array to track which ones have been sent.
+var blocksTracked = [];
 if (typeof analytics !== 'undefined') {
     analytics.page('Landing', __assign({ variation: PAGE_NAME }, getGoogleAnalyticsProperties()));
 }
@@ -99,8 +104,10 @@ function getInterviewerPlayerEventProperties(target) {
         name: interviewerName
     };
 }
-// Take the target of an event and return an object of the relevant properties to be included in the tracking event.
-// Return `null` if the event should not be sent.
+/**
+ * Take the target of an event and return an object of the relevant properties to be included in the tracking event.
+ * Return `null` if the event should not be sent.
+ */
 function getEventProperties(eventName, target) {
     var eventProperties = {};
     var dataset = target.dataset;
@@ -133,17 +140,16 @@ function getEventProperties(eventName, target) {
     }
     return eventProperties;
 }
-// It is possible for browsers to block the Sentry script from being downloaded, so capture messages safely.
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
+/**
+ * It is possible for browsers to block the Sentry script from being downloaded, so capture messages safely.
+ */
 function safelyCaptureMessage(message, level) {
     if (level === void 0) { level = null; }
     if (typeof Sentry !== 'undefined') {
         Sentry.captureMessage(message, level);
     }
 }
-// Assign a click event for any element with `data-event-name` set.
-// The element should also have the `data-event-label` and `data-event-block` custom attributes set.
-$('[data-event-name]').on('click', function () {
+function buttonClickedEvent() {
     var target = $(this).closest('[data-event-name]')[0];
     var eventName = target.getAttribute('data-event-name');
     var eventProperties = getEventProperties(eventName, target);
@@ -154,4 +160,31 @@ $('[data-event-name]').on('click', function () {
     // `getEventProperties` will return `null` if the event should not be sent.
     if (eventProperties)
         sendEvent(eventName, eventProperties);
-});
+}
+function viewedLandingPageBlockEvent(entries) {
+    for (var _i = 0, entries_1 = entries; _i < entries_1.length; _i++) {
+        var entry = entries_1[_i];
+        if (entry.isIntersecting) {
+            var target = entry.target;
+            var blockName = $(target).attr('data-event-block');
+            if (blocksTracked.indexOf(blockName) === -1) {
+                var eventName = viewedLandingPageBlockEventName;
+                var eventProperties = getEventProperties(eventName, target);
+                sendEvent(eventName, eventProperties);
+                blocksTracked.push(blockName);
+            }
+        }
+    }
+}
+// Assign event listeners for analytics events based on the `data-event-name` attribute.
+(function () {
+    var blockObserver = new IntersectionObserver(viewedLandingPageBlockEvent);
+    $("[data-event-name=\"".concat(viewedLandingPageBlockEventName, "\"]")).each(function () { blockObserver.observe(this); });
+    $("[data-event-name=\"".concat(buttonClickedEventName, "\"]")).on('click', buttonClickedEvent);
+    // Send a warning if we specified an invalid event name in an element's custom attributes.
+    var expectedEventsNames = [buttonClickedEventName, viewedLandingPageBlockEventName];
+    var expectedEventSelectors = expectedEventsNames.map(function (eventName) { return "[data-event-name=\"".concat(eventName, "\"]"); }).join(', ');
+    $('[data-event-name]').not(expectedEventSelectors).each(function () {
+        safelyCaptureMessage("Unexpected event name specified in Webflow: ".concat($(this).attr('data-event-name'), "."), 'warning');
+    });
+})();

--- a/dist/analytics.js
+++ b/dist/analytics.js
@@ -10,6 +10,7 @@ var __assign = (this && this.__assign) || function () {
     return __assign.apply(this, arguments);
 };
 var buttonClickedEventName = 'Button Clicked';
+var faqOpenedEventName = 'FAQs Opened';
 var viewedLandingPageBlockEventName = 'Viewed Landing Page Block';
 // We don't want to send the `Viewed Landing Page Block` event multiple times per block on the same visit, so use this
 // array to track which ones have been sent.
@@ -73,6 +74,7 @@ function getBlockProperties(block) {
         interviewers: 'carousel',
         'packages-and-pricing': 'basic',
         pricing: 'basic',
+        'sample-questions': 'carousel',
         subscribe: 'basic',
         testimonials: 'carousel',
         ticker: 'basic',
@@ -181,8 +183,9 @@ function viewedLandingPageBlockEvent(entries) {
     var blockObserver = new IntersectionObserver(viewedLandingPageBlockEvent);
     $("[data-event-name=\"".concat(viewedLandingPageBlockEventName, "\"]")).each(function () { blockObserver.observe(this); });
     $("[data-event-name=\"".concat(buttonClickedEventName, "\"]")).on('click', buttonClickedEvent);
+    $("[data-event-name=\"".concat(faqOpenedEventName, "\"]")).on('click', buttonClickedEvent);
     // Send a warning if we specified an invalid event name in an element's custom attributes.
-    var expectedEventsNames = [buttonClickedEventName, viewedLandingPageBlockEventName];
+    var expectedEventsNames = [buttonClickedEventName, faqOpenedEventName, viewedLandingPageBlockEventName];
     var expectedEventSelectors = expectedEventsNames.map(function (eventName) { return "[data-event-name=\"".concat(eventName, "\"]"); }).join(', ');
     $('[data-event-name]').not(expectedEventSelectors).each(function () {
         safelyCaptureMessage("Unexpected event name specified in Webflow: ".concat($(this).attr('data-event-name'), "."), 'warning');

--- a/dist/animations.js
+++ b/dist/animations.js
@@ -508,10 +508,12 @@ function sampleQuestionAnimationCleanup(animationName) {
     }
 }
 var FAILED_GET_SAMPLE_QUESTION_COMPONENTS_ATTEMPTS = 0;
-// The script we use to tie Webflow's CMS into a slider will move the elements within the DOM, which can cause issues
-// when trying to select those elements. Attempt to fetch the components for 10 seconds before sending a Sentry alert.
-// TODO: See if we can execute the `@finsweet/attributes-cmsslider` script from this file, then only run this function
-// after that script finishes.
+/**
+ * The script we use to tie Webflow's CMS into a slider will move the elements within the DOM, which can cause issues
+ * when trying to select those elements. Attempt to fetch the components for 10 seconds before sending a Sentry alert.
+ * TODO: See if we can execute the `@finsweet/attributes-cmsslider` script from this file, then only run this function
+ * after that script finishes.
+ */
 function getSampleQuestionComponents() {
     var sampleQuestionsContainer = $('.section-sample-questions .container-basic');
     for (var _i = 0, SAMPLE_QUESTION_ANIMATIONS_1 = SAMPLE_QUESTION_ANIMATIONS; _i < SAMPLE_QUESTION_ANIMATIONS_1.length; _i++) {
@@ -557,7 +559,9 @@ function onSampleQuestionSectionIntersection(entries, audioSourceToAnimationName
         safelyCaptureMessage('An intersection observer entry was not included when calling `onSampleQuestionSectionIntersection`.', 'info');
     }
 }
-// Set up the animations.
+/**
+ * Set up the animations
+ */
 (function () {
     var audioSourceToAnimationNameMap = {};
     SAMPLE_QUESTION_ANIMATIONS.forEach(function (animationName) {

--- a/dist/player.js
+++ b/dist/player.js
@@ -69,7 +69,9 @@ function sendAnalyticsEvent(eventName, eventProperties) {
         safelyCaptureMessage('`sendEvent` was called before it was loaded.');
     }
 }
-// Attempt to retrieve animation info, if it exists, and sync the audio player to the animation.
+/**
+ * Attempt to retrieve animation info, if it exists, and sync the audio player to the animation.
+ */
 function syncAudioPlayerAndAnimation() {
     if (typeof currentAnimationInfo !== 'undefined' && typeof ANIMATIONS !== 'undefined') {
         if (currentAnimationInfo.name in ANIMATIONS) {

--- a/src/analytics.ts
+++ b/src/analytics.ts
@@ -1,4 +1,5 @@
 const buttonClickedEventName = 'Button Clicked'
+const faqOpenedEventName = 'FAQs Opened'
 const viewedLandingPageBlockEventName = 'Viewed Landing Page Block'
 
 // We don't want to send the `Viewed Landing Page Block` event multiple times per block on the same visit, so use this
@@ -77,6 +78,7 @@ function getBlockProperties(block: string) {
         interviewers: 'carousel',
         'packages-and-pricing': 'basic',
         pricing: 'basic',
+        'sample-questions': 'carousel',
         subscribe: 'basic',
         testimonials: 'carousel',
         ticker: 'basic',
@@ -206,9 +208,10 @@ function viewedLandingPageBlockEvent(entries: IntersectionObserverEntry[]) {
     $(`[data-event-name="${viewedLandingPageBlockEventName}"]`).each(function() { blockObserver.observe(this) })
 
     $(`[data-event-name="${buttonClickedEventName}"]`).on('click', buttonClickedEvent)
+    $(`[data-event-name="${faqOpenedEventName}"]`).on('click', buttonClickedEvent)
 
     // Send a warning if we specified an invalid event name in an element's custom attributes.
-    const expectedEventsNames = [buttonClickedEventName, viewedLandingPageBlockEventName]
+    const expectedEventsNames = [buttonClickedEventName, faqOpenedEventName, viewedLandingPageBlockEventName]
     const expectedEventSelectors = expectedEventsNames.map(eventName => `[data-event-name="${eventName}"]`).join(', ')
     $('[data-event-name]').not(expectedEventSelectors).each(function() {
         safelyCaptureMessage(

--- a/src/analytics.ts
+++ b/src/analytics.ts
@@ -78,6 +78,11 @@ function getBlockProperties(block: string) {
         'your-child': 'basic'
     }
 
+    if (!(block in blockVariants)) {
+        safelyCaptureMessage(`The ${block} block is not defined getBlockProperties.`, 'warning')
+        return {}
+    }
+
     const blockProperties: BlockEventProperties = { 'block-variant': blockVariants[block] }
     if (block === 'topnav') {
         // TODO: This will not be adequate for the interactive hero section where the topnav does not get pinned until
@@ -157,6 +162,14 @@ $('[data-event-name]').on('click', function() {
     const target = $(this).closest('[data-event-name]')[0]
     const eventName = target.getAttribute('data-event-name')
     const eventProperties = getEventProperties(eventName, target)
+
+    // All click events should have a `block` property defined.
+    if (!('block' in eventProperties)) {
+        safelyCaptureMessage(
+            `The block property has not been set for a click event with the name, ${eventName}.`,
+            'warning'
+        )
+    }
 
     // `getEventProperties` will return `null` if the event should not be sent.
     if (eventProperties) sendEvent(eventName, eventProperties)

--- a/src/analytics.ts
+++ b/src/analytics.ts
@@ -88,7 +88,7 @@ function getBlockProperties(block: string) {
     }
 
     if (!(block in blockVariants)) {
-        safelyCaptureMessage(`The ${block} block is not defined getBlockProperties.`, 'warning')
+        safelyCaptureMessage(`An invalid block name, ${block}, was passed to getBlockProperties.`, 'warning')
         return {}
     }
 

--- a/src/animations.ts
+++ b/src/animations.ts
@@ -527,10 +527,12 @@ function sampleQuestionAnimationCleanup(animationName: AnimationName) {
 
 let FAILED_GET_SAMPLE_QUESTION_COMPONENTS_ATTEMPTS = 0
 
-// The script we use to tie Webflow's CMS into a slider will move the elements within the DOM, which can cause issues
-// when trying to select those elements. Attempt to fetch the components for 10 seconds before sending a Sentry alert.
-// TODO: See if we can execute the `@finsweet/attributes-cmsslider` script from this file, then only run this function
-// after that script finishes.
+/**
+ * The script we use to tie Webflow's CMS into a slider will move the elements within the DOM, which can cause issues
+ * when trying to select those elements. Attempt to fetch the components for 10 seconds before sending a Sentry alert.
+ * TODO: See if we can execute the `@finsweet/attributes-cmsslider` script from this file, then only run this function
+ * after that script finishes.
+ */
 function getSampleQuestionComponents() {
     const sampleQuestionsContainer = $('.section-sample-questions .container-basic')
     for (const animationName of SAMPLE_QUESTION_ANIMATIONS) {
@@ -588,7 +590,9 @@ function onSampleQuestionSectionIntersection(entries: IntersectionObserverEntry[
 }
 
 
-// Set up the animations.
+/**
+ * Set up the animations
+ */
 (() => {
     const audioSourceToAnimationNameMap: Record<string, AnimationName> = {}
     SAMPLE_QUESTION_ANIMATIONS.forEach((animationName) => {

--- a/src/player.ts
+++ b/src/player.ts
@@ -43,7 +43,9 @@ function sendAnalyticsEvent(eventName: string, eventProperties: EventProperties)
 }
 
 
-// Attempt to retrieve animation info, if it exists, and sync the audio player to the animation.
+/**
+ * Attempt to retrieve animation info, if it exists, and sync the audio player to the animation.
+ */
 function syncAudioPlayerAndAnimation() {
     if (typeof currentAnimationInfo !== 'undefined' && typeof ANIMATIONS !== 'undefined') {
         if (currentAnimationInfo.name in ANIMATIONS) {


### PR DESCRIPTION
## Testing Instructions:

- Make sure `Button Clicked` and `FAQs Opened` events are still coming through as before.
- Scroll down the page and make sure there are events being triggered each time a new block scrolls into view. Blocks should not send a second event if you scroll them into view a second time on that visit.
- To test the new Sentry alerts (make sure you undo each of these changes after testing):
  - Provide an invalid `data-event-name` attribute to any element.
  - Provide an invalid `data-event-block` attribute to any element that triggers `Button Clicked`.
  - Remove the `data-event-block` attribute from any element that triggers `Button Clicked`.