### PR TITLE
Analytics fixes

### DIFF
--- a/dist/analytics.js
+++ b/dist/analytics.js
@@ -77,6 +77,7 @@ function getBlockProperties(block) {
         pricing: 'basic',
         'sample-questions': 'carousel',
         subscribe: 'basic',
+        'start-building': 'basic',
         testimonials: 'carousel',
         ticker: 'basic',
         topnav: 'basic',

--- a/dist/analytics.js
+++ b/dist/analytics.js
@@ -97,7 +97,7 @@ function getBlockProperties(block) {
     return blockProperties;
 }
 function getFAQEventProperties(target) {
-    var questionText = $(target).children().first().children().first().text();
+    var questionText = $(target).find('.question-wrapper').first().text();
     return { block: 'FAQs', name: questionText, type: 'question' };
 }
 function getInterviewerPlayerEventProperties(target) {

--- a/dist/analytics.js
+++ b/dist/analytics.js
@@ -152,9 +152,10 @@ function safelyCaptureMessage(message, level) {
         Sentry.captureMessage(message, level);
     }
 }
-function buttonClickedEvent() {
+function buttonClickedEvent(eventNameOverride) {
+    if (eventNameOverride === void 0) { eventNameOverride = null; }
     var target = $(this).closest('[data-event-name]')[0];
-    var eventName = buttonClickedEventName;
+    var eventName = eventNameOverride || buttonClickedEventName;
     var eventProperties = getEventProperties(eventName, target);
     // All click events should have a `block` property defined.
     if (!('block' in eventProperties)) {
@@ -191,8 +192,10 @@ function viewedLandingPageBlockEvent(entries) {
 (function () {
     var blockObserver = new IntersectionObserver(viewedLandingPageBlockEvent);
     $("[data-event-name=\"".concat(viewedLandingPageBlockEventName, "\"]")).each(function () { blockObserver.observe(this); });
-    $("[data-event-name=\"".concat(buttonClickedEventName, "\"]")).on('click', buttonClickedEvent);
-    $("[data-event-name=\"".concat(faqOpenedEventName, "\"]")).on('click', buttonClickedEvent);
+    $("[data-event-name=\"".concat(buttonClickedEventName, "\"]")).on('click', function () { buttonClickedEvent.bind(this)(); });
+    $("[data-event-name=\"".concat(faqOpenedEventName, "\"]")).on('click', function () {
+        buttonClickedEvent.bind(this)(faqOpenedEventName);
+    });
     $("[data-event-name=\"".concat(kidConversionFlowStartedEventName, "\"]")).on('click', kidConversionFlowStartedEvent);
     // Send a warning if we specified an invalid event name in an element's custom attributes.
     var expectedEventsNames = [

--- a/src/analytics.ts
+++ b/src/analytics.ts
@@ -169,9 +169,9 @@ function safelyCaptureMessage(message: string, level: SeverityLevel = null) {
 }
 
 
-function buttonClickedEvent(this: HTMLElement) {
+function buttonClickedEvent(this: HTMLElement, eventNameOverride: string = null) {
     const target = $(this).closest('[data-event-name]')[0]
-    const eventName = buttonClickedEventName
+    const eventName = eventNameOverride || buttonClickedEventName
     const eventProperties = getEventProperties(eventName, target)
 
     // All click events should have a `block` property defined.
@@ -220,8 +220,10 @@ function viewedLandingPageBlockEvent(entries: IntersectionObserverEntry[]) {
     const blockObserver = new IntersectionObserver(viewedLandingPageBlockEvent)
     $(`[data-event-name="${viewedLandingPageBlockEventName}"]`).each(function() { blockObserver.observe(this) })
 
-    $(`[data-event-name="${buttonClickedEventName}"]`).on('click', buttonClickedEvent)
-    $(`[data-event-name="${faqOpenedEventName}"]`).on('click', buttonClickedEvent)
+    $(`[data-event-name="${buttonClickedEventName}"]`).on('click', function() { buttonClickedEvent.bind(this)() })
+    $(`[data-event-name="${faqOpenedEventName}"]`).on('click', function() {
+        buttonClickedEvent.bind(this)(faqOpenedEventName)
+    })
 
     $(`[data-event-name="${kidConversionFlowStartedEventName}"]`).on('click', kidConversionFlowStartedEvent)
 

--- a/src/analytics.ts
+++ b/src/analytics.ts
@@ -81,6 +81,7 @@ function getBlockProperties(block: string) {
         pricing: 'basic',
         'sample-questions': 'carousel',
         subscribe: 'basic',
+        'start-building': 'basic',
         testimonials: 'carousel',
         ticker: 'basic',
         topnav: 'basic',

--- a/src/analytics.ts
+++ b/src/analytics.ts
@@ -105,7 +105,7 @@ function getBlockProperties(block: string) {
 
 
 function getFAQEventProperties(target: HTMLElement) {
-    const questionText = $(target).children().first().children().first().text()
+    const questionText = $(target).find('.question-wrapper').first().text()
     return { block: 'FAQs', name: questionText, type: 'question' }
 }
 


### PR DESCRIPTION
7d6b4f1ae0234aeab9fcb694373cf11a6500c613:
- Fixes this bug: https://sentry.io/organizations/artifact/issues/3594222149/
- We infer the block from the fact that it's an FAQ event, but the event name was hard-coded to `Button Clicked` yesterday.

2644bb70bcb39953364c9c968b8a0b88e19c108f:
- Fixes this bug: https://sentry.io/organizations/artifact/issues/3609535876/

09911333f545c81efe3af10099f39efd2a6ed2db:
- Fixes a bug where the question was not found to include in the events (`name` should not be empty).
- <img width="321" alt="Screen Shot 2022-09-21 at 1 03 00 PM" src="https://user-images.githubusercontent.com/68879394/191566960-dbff43d7-10c1-4bd8-b866-b4a8b39c77b3.png">
