### PR TITLE
Include experiment cookie in Sentry messages

### DIFF
--- a/dist/analytics.js
+++ b/dist/analytics.js
@@ -149,10 +149,10 @@ function getEventProperties(eventName, target) {
  */
 function safelyCaptureMessage(message, level, context) {
     if (level === void 0) { level = null; }
-    if (context === void 0) { context = {}; }
+    if (context === void 0) { context = null; }
     if (typeof Sentry !== 'undefined') {
         Sentry.withScope(function (scope) {
-            if (typeof context.properties !== 'undefined') {
+            if (context) {
                 var contextName = context.name || 'Custom Context';
                 scope.setContext(contextName, context.properties);
             }

--- a/dist/analytics.js
+++ b/dist/analytics.js
@@ -55,7 +55,7 @@ function getGoogleAnalyticsProperties() {
                 return { experiment_group: experimentGroup, experiment_id: experimentId };
             }
         }
-        safelyCaptureMessage('The Google Optimize experiment group could not be determined.', 'warning');
+        safelyCaptureMessage('The Google Optimize experiment group could not be determined.', 'warning', { properties: { experimentCookie: experimentCookie } });
     }
     return {};
 }
@@ -147,10 +147,17 @@ function getEventProperties(eventName, target) {
 /**
  * It is possible for browsers to block the Sentry script from being downloaded, so capture messages safely.
  */
-function safelyCaptureMessage(message, level) {
+function safelyCaptureMessage(message, level, context) {
     if (level === void 0) { level = null; }
+    if (context === void 0) { context = {}; }
     if (typeof Sentry !== 'undefined') {
-        Sentry.captureMessage(message, level);
+        Sentry.withScope(function (scope) {
+            if (typeof context.properties !== 'undefined') {
+                var contextName = context.name || 'Custom Context';
+                scope.setContext(contextName, context.properties);
+            }
+            Sentry.captureMessage(message, level);
+        });
     }
 }
 function buttonClickedEvent(eventNameOverride) {

--- a/main.d.ts
+++ b/main.d.ts
@@ -2,7 +2,7 @@ declare const dataLayer: unknown[]
 declare const google_optimize: { get: (experimentId: string) => string | undefined}
 declare const PAGE_NAME: string
 declare let player: HTMLAudioElement
-declare const Sentry: import('@sentry/types').Client
+declare const Sentry: import('@sentry/types').Hub
 
 type SeverityLevel = import('@sentry/types').SeverityLevel
 
@@ -50,6 +50,11 @@ type KaraokeAnimationInfo = {
 type KaraokeState = {
     currentQuoteStart: number
     stagedWords: StagedWord[]
+}
+
+type SentryContext = {
+    name?: string
+    properties?: Record<string, string>
 }
 
 type StagedWord = UtteranceWord & { element: HTMLSpanElement }

--- a/main.d.ts
+++ b/main.d.ts
@@ -54,7 +54,7 @@ type KaraokeState = {
 
 type SentryContext = {
     name?: string
-    properties?: Record<string, string>
+    properties: Record<string, string>
 }
 
 type StagedWord = UtteranceWord & { element: HTMLSpanElement }

--- a/src/analytics.ts
+++ b/src/analytics.ts
@@ -51,7 +51,11 @@ function getGoogleAnalyticsProperties() {
                 return { experiment_group: experimentGroup, experiment_id: experimentId }
             }
         }
-        safelyCaptureMessage('The Google Optimize experiment group could not be determined.', 'warning')
+        safelyCaptureMessage(
+            'The Google Optimize experiment group could not be determined.',
+            'warning',
+            { properties: { experimentCookie } }
+        )
     }
     return {}
 }
@@ -163,9 +167,15 @@ function getEventProperties(eventName: string, target: HTMLElement) {
 /**
  * It is possible for browsers to block the Sentry script from being downloaded, so capture messages safely.
  */
-function safelyCaptureMessage(message: string, level: SeverityLevel = null) {
+function safelyCaptureMessage(message: string, level: SeverityLevel = null, context: SentryContext = {}) {
     if (typeof Sentry !== 'undefined') {
-        Sentry.captureMessage(message, level)
+        Sentry.withScope(function (scope) {
+            if (typeof context.properties !== 'undefined') {
+                const contextName = context.name || 'Custom Context'
+                scope.setContext(contextName, context.properties)
+            }
+            Sentry.captureMessage(message, level)
+        })
     }
 }
 

--- a/src/analytics.ts
+++ b/src/analytics.ts
@@ -167,10 +167,10 @@ function getEventProperties(eventName: string, target: HTMLElement) {
 /**
  * It is possible for browsers to block the Sentry script from being downloaded, so capture messages safely.
  */
-function safelyCaptureMessage(message: string, level: SeverityLevel = null, context: SentryContext = {}) {
+function safelyCaptureMessage(message: string, level: SeverityLevel = null, context: SentryContext = null) {
     if (typeof Sentry !== 'undefined') {
         Sentry.withScope(function (scope) {
-            if (typeof context.properties !== 'undefined') {
+            if (context) {
                 const contextName = context.name || 'Custom Context'
                 scope.setContext(contextName, context.properties)
             }


### PR DESCRIPTION
I've noticed some events do not have the experiment ID attached when they should. I'm not sure what the cause is yet, but including the cooking in the Sentry messages might help debug. Will Slack more details.
