### PR TITLE
Bug fixes

### DIFF
--- a/dist/analytics.js
+++ b/dist/analytics.js
@@ -35,6 +35,9 @@ for (var _i = 0, _a = [5, 15, 30, 45]; _i < _a.length; _i++) {
  * Example cookie: _gaexp=GAX1.2.OLD_EXPERIMENT_ID.19285.1!NEW_EXPERIMENT_ID.19286.0
  */
 function getGoogleAnalyticsProperties() {
+    // Google Optimize is only set to run in production.
+    if (ENVIRONMENT !== 'production')
+        return {};
     var cookieString = document.cookie;
     var cookies = cookieString.split('; ');
     var experimentCookie = cookies.find(function (cookie) { return cookie.startsWith('_gaexp='); });

--- a/dist/analytics.js
+++ b/dist/analytics.js
@@ -165,13 +165,14 @@ function buttonClickedEvent(eventNameOverride) {
     var target = $(this).closest('[data-event-name]')[0];
     var eventName = eventNameOverride || buttonClickedEventName;
     var eventProperties = getEventProperties(eventName, target);
+    // `getEventProperties` will return `null` if the event should not be sent.
+    if (!eventProperties)
+        return;
     // All click events should have a `block` property defined.
     if (!('block' in eventProperties)) {
         safelyCaptureMessage("The block property has not been set for a click event with the name, ".concat(eventName, "."), 'warning');
     }
-    // `getEventProperties` will return `null` if the event should not be sent.
-    if (eventProperties)
-        sendEvent(eventName, eventProperties);
+    sendEvent(eventName, eventProperties);
 }
 function kidConversionFlowStartedEvent() {
     // Send the button clicked event to Segment.

--- a/main.d.ts
+++ b/main.d.ts
@@ -3,6 +3,8 @@ declare const google_optimize: { get: (experimentId: string) => string | undefin
 declare const PAGE_NAME: string
 declare let player: HTMLAudioElement
 declare const Sentry: import('@sentry/types').Hub
+// The environment is inferred in the project's custom code based on the domain/subdomain.
+declare const ENVIRONMENT: 'production' | 'staging' | 'testing'
 
 type SeverityLevel = import('@sentry/types').SeverityLevel
 

--- a/src/analytics.ts
+++ b/src/analytics.ts
@@ -28,6 +28,9 @@ for (const delay of [5, 15, 30, 45]) {
  * Example cookie: _gaexp=GAX1.2.OLD_EXPERIMENT_ID.19285.1!NEW_EXPERIMENT_ID.19286.0
  */
 function getGoogleAnalyticsProperties() {
+    // Google Optimize is only set to run in production.
+    if (ENVIRONMENT !== 'production') return {}
+
     const cookieString = document.cookie
     const cookies = cookieString.split('; ')
     const experimentCookie = cookies.find(cookie => cookie.startsWith('_gaexp='))

--- a/src/analytics.ts
+++ b/src/analytics.ts
@@ -185,6 +185,9 @@ function buttonClickedEvent(this: HTMLElement, eventNameOverride: string = null)
     const eventName = eventNameOverride || buttonClickedEventName
     const eventProperties = getEventProperties(eventName, target)
 
+    // `getEventProperties` will return `null` if the event should not be sent.
+    if (!eventProperties) return
+
     // All click events should have a `block` property defined.
     if (!('block' in eventProperties)) {
         safelyCaptureMessage(
@@ -193,8 +196,7 @@ function buttonClickedEvent(this: HTMLElement, eventNameOverride: string = null)
         )
     }
 
-    // `getEventProperties` will return `null` if the event should not be sent.
-    if (eventProperties) sendEvent(eventName, eventProperties)
+    sendEvent(eventName, eventProperties)
 }
 
 


### PR DESCRIPTION
Minor improvements here, neither bug is page-breaking so this isn't urgent.

02a4dafb62074c7a2fef0f4a5e9384c3a3580467:
- `getEventProperties` returns `null` when an FAQ item is closed, indicating that an event should not be set. This caused a bug when checking `'block' in eventProperties`

e00aad0954de2a976db4de1eec65222e6dc7c1cb:
- Fixes one Sentry alert from surfacing on staging. A few people may still have a cookie set on staging when we were first testing/building the AB tests. 