### PR TITLE
Move safelyCaptureMessage to Webflow custom code

### DIFF
--- a/dist/analytics.js
+++ b/dist/analytics.js
@@ -154,15 +154,6 @@ function getEventProperties(eventName, target) {
     }
     return eventProperties;
 }
-/**
- * It is possible for browsers to block the Sentry script from being downloaded, so capture messages safely.
- */
-function safelyCaptureMessage(message, level) {
-    if (level === void 0) { level = null; }
-    if (typeof Sentry !== 'undefined') {
-        Sentry.captureMessage(message, level);
-    }
-}
 function buttonClickedEvent(eventNameOverride) {
     if (eventNameOverride === void 0) { eventNameOverride = null; }
     var target = $(this).closest('[data-event-name]')[0];

--- a/main.d.ts
+++ b/main.d.ts
@@ -8,6 +8,9 @@ declare const ENVIRONMENT: 'production' | 'staging' | 'testing'
 
 type SeverityLevel = import('@sentry/types').SeverityLevel
 
+// safelyCaptureMessage is defined in Webflow's custom code to handle the case where the client blocks analytics.js.
+declare const safelyCaptureMessage: (message: string, level?: SeverityLevel) => void
+
 type BlockEventProperties = {
     'block-variant': BlockVariant
     'topnav-pinned'?: boolean

--- a/src/analytics.ts
+++ b/src/analytics.ts
@@ -173,16 +173,6 @@ function getEventProperties(eventName: string, target: HTMLElement) {
 }
 
 
-/**
- * It is possible for browsers to block the Sentry script from being downloaded, so capture messages safely.
- */
-function safelyCaptureMessage(message: string, level: SeverityLevel = null) {
-    if (typeof Sentry !== 'undefined') {
-        Sentry.captureMessage(message, level)
-    }
-}
-
-
 function buttonClickedEvent(this: HTMLElement, eventNameOverride: string = null) {
     const target = $(this).closest('[data-event-name]')[0]
     const eventName = eventNameOverride || buttonClickedEventName


### PR DESCRIPTION
Fixes this bug: https://sentry.io/organizations/artifact/issues/3805714377/

The first part of the issue is that some clients block the Sentry script, so we need to safely call Sentry.
The second part of the issue is that `analytics.js` could also be blocked, so the function to safely call Sentry was not available.

By moving the function into the custom code of Webflow, it's available across all pages (and is still non-blocking).